### PR TITLE
Speed up BufBitReader read paths, then remediate review findings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,12 @@ name: Rust
 
 on: ["push", "pull_request"]
 
+# Least-privilege default token: jobs only need to read repository contents.
+# The coverage job uploads to Coveralls using GITHUB_TOKEN, which needs only
+# read access here.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -9,7 +15,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Check formatting
         run: cargo fmt -- --check
       - name: Clippy (default)
@@ -23,9 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Install rust (1.85.0)
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: 1.85.0
       - name: Check (MSRV, all features)
@@ -49,10 +55,10 @@ jobs:
 
     steps:
       - name: Install rust (${{ matrix.rust }})
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: ${{ matrix.rust }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Build
         run: cargo build --verbose ${{ matrix.features }}
       - name: Test
@@ -64,18 +70,18 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     container:
-      image: xd009642/tarpaulin:develop-nightly
+      image: xd009642/tarpaulin@sha256:d4859b7bb3e2887e4147b393708e20b094b72843c4dc1d226f9f29fe271701ce # develop-nightly
       options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Generate code coverage
         run: |
           cargo +nightly tarpaulin --verbose --engine llvm --all-features --workspace --out Lcov
 
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: "lcov.info"
@@ -83,7 +89,7 @@ jobs:
   build-i686:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Install 32-bit support
         run: sudo apt-get update && sudo apt-get install -y gcc-multilib
       - name: Add i686 target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## [Unreleased]
 
+### New
+
+- `WordRead` has a new method with a default implementation:
+  `read_word_opt`, atomically reading and consuming the next word if the
+  backend can determine cheaply that one is available (`None` otherwise,
+  never failing and never consuming past the end). `MemWordReader`
+  implements it.
+
+### Improved
+
+- `BufBitReader::read_bits` and `BufBitReader::read_unary` are significantly
+  faster: word-crossing reads of at most one word are composed with
+  straight-line code instead of the general word loop, and, on peekable
+  backends, refills load two words when possible, halving refill events and
+  branch mispredictions. The bit buffer still never fills completely, so the
+  hot paths carry no full-buffer handling. On Zen 4 with a u32 read word,
+  decoder read benchmarks (74 cases: gamma, delta, zeta, pi, rice,
+  exp-Golomb, Golomb, omega, unary, vbyte; both endians, implied and
+  universal distributions) measure a 17% geometric-mean speedup, up to -33%
+  on exp-Golomb and pi reads; u64-read-word unary decoding is ~13% faster.
+
 ### Fixed
 
 - The big-endian `BufBitReader::copy_to` no longer leaves already-copied bits

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,8 @@ offset_of_enum = []
 serde = ["dep:serde", "alloc"]
 # Benchmark-only feature flags
 bench-reads = []
+# u32 is the default word size; enable bench-u16 or bench-u64 to override it.
 bench-u16 = []
-bench-u32 = []
 bench-u64 = []
 bench-univ = []
 bench-delta-gamma = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 rand = { version = "0.10.0", optional = true }
 arbitrary = { version = "1", features = ["derive"], optional = true }
 num-primitive = { version = "=0.2.1", default-features = false }
-mem_dbg = { version = ">=0.4.1", optional = true }
+mem_dbg = { version = "0.4.1", optional = true }
 serde = { version = "1.0.228", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,3 +74,15 @@ harness = false
 [[bench]]
 name = "vbyte"
 harness = false
+
+[[bench]]
+name = "bufbitreader"
+harness = false
+
+[[bench]]
+name = "bufbitreader_gamma"
+harness = false
+
+[[bench]]
+name = "bufbitreader_wa"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,9 @@ serde = { version = "1.0.228", optional = true }
 dsi-bitstream = { path = ".", features = ["implied"] }
 criterion = "0.6.0"
 rand = "0.10.0"
-zip = "7.0.0"
+# default-features disabled to drop the optional `time` dependency (and other
+# codecs) we do not use; the checked-in corpora are STORED or DEFLATED only.
+zip = { version = "7.0.0", default-features = false, features = ["deflate"] }
 rand_distr = "0.6.0"
 serde_json = "1.0"
 

--- a/autoresearch.sh
+++ b/autoresearch.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Autoresearch harness: focused BufBitReader read benchmarks.
+#
+# Runs three Criterion legs and prints METRIC lines with the mean ns/op of
+# each case plus their geometric mean as the primary metric:
+#   1. `bufbitreader` (u32 read word): read_unary and read_bits anchors;
+#   2. `bufbitreader_gamma` (u32): composite read_gamma through the public
+#      code API, in a separate binary so the anchors keep their code layout;
+#   3. `bufbitreader` with `bench-u64` (u64 read word, u128 bit buffer), in
+#      its own CARGO_TARGET_DIR so the feature toggle does not thrash the
+#      main build cache.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+echo "# $(uname -srm) | $(rustc -V) | target-cpu=native (.cargo/config.toml)" >&2
+
+TARGET="${CARGO_TARGET_DIR:-target}"
+U64_TARGET="$TARGET/u64"
+
+# Remove stale estimates for these groups so a failed bench run cannot leave
+# old results behind for the extraction step to pick up.
+rm -rf "$TARGET/criterion/bufbitreader"
+rm -rf "$TARGET/criterion/bufbitreader_gamma"
+rm -rf "$U64_TARGET/criterion/bufbitreader_u64"
+
+# Criterion output goes to stderr; only METRIC lines belong on stdout.
+cargo bench --bench bufbitreader --features implied -- --noplot >&2
+cargo bench --bench bufbitreader_gamma --features implied -- --noplot >&2
+CARGO_TARGET_DIR="$U64_TARGET" cargo bench --bench bufbitreader \
+    --features implied,bench-u64 -- --noplot >&2
+
+python3 - <<'EOF'
+import math
+import os
+import sys
+
+sys.path.insert(0, "python")
+from extract_criterion import get_criterion_results
+
+results = get_criterion_results()
+results.update(
+    get_criterion_results(
+        os.path.join(os.environ.get("CARGO_TARGET_DIR", "target"), "u64", "criterion")
+    )
+)
+n = 1_000_000  # matches common::N
+
+cases = {
+    "bufbitreader_read_unary_BE": "read_unary_be_ns",
+    "bufbitreader_read_unary_LE": "read_unary_le_ns",
+    "bufbitreader_read_bits_BE": "read_bits_be_ns",
+    "bufbitreader_read_bits_LE": "read_bits_le_ns",
+    "bufbitreader_gamma_read_gamma_BE": "read_gamma_be_ns",
+    "bufbitreader_gamma_read_gamma_LE": "read_gamma_le_ns",
+    "bufbitreader_u64_read_unary_BE": "read_unary_u64_be_ns",
+    "bufbitreader_u64_read_unary_LE": "read_unary_u64_le_ns",
+    "bufbitreader_u64_read_bits_BE": "read_bits_u64_be_ns",
+    "bufbitreader_u64_read_bits_LE": "read_bits_u64_le_ns",
+}
+
+vals = []
+for bench_id, metric in cases.items():
+    if bench_id not in results:
+        sys.exit(f"missing criterion result: {bench_id}")
+    ns_per_op = results[bench_id]["mean_ns"] / n
+    vals.append(ns_per_op)
+    print(f"METRIC {metric}={ns_per_op:.4f}")
+
+geomean = math.exp(sum(map(math.log, vals)) / len(vals))
+print(f"METRIC read_ns_geomean={geomean:.4f}")
+EOF

--- a/benches/README.md
+++ b/benches/README.md
@@ -18,7 +18,7 @@ The distribution is controlled by the `bench-univ` feature: without it, each
 code's implied distribution is used; with it, a universal Zipf distribution
 ≈1/_x_ on the first billion integers is used.
 
-Word size is controlled by features: `bench-u16`, `bench-u32`, or `bench-u64`.
+Word size defaults to `u32`; enable `bench-u16` or `bench-u64` to override it.
 The feature `bench-reads` tests reads; without it, writes are tested. The
 feature `bench-delta-gamma` tests δ codes with 9-bit tables for γ codes.
 
@@ -81,7 +81,7 @@ Criterion timing can be controlled via CLI options passed after `--`:
 
 ```bash
 # Quick dry run
-cargo bench --bench tables --features implied,bench-reads,bench-u32 -- --warm-up-time 0.01 --measurement-time 0.01
+cargo bench --bench tables --features implied,bench-reads -- --warm-up-time 0.01 --measurement-time 0.01
 
 # Fine-grained table benchmarks
     ./python/gen_table_plots.sh implied -- --warm-up-time 0.5 --measurement-time 1

--- a/benches/bufbitreader.rs
+++ b/benches/bufbitreader.rs
@@ -1,0 +1,174 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Tommaso Fontana
+ * SPDX-FileCopyrightText: 2026 Sebastiano Vigna
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+//! Focused Criterion benchmarks for [`BufBitReader`]: raw `read_unary` and
+//! `read_bits` calls, big and little endian.
+//!
+//! The `comparative` benchmark exercises `read_unary` directly (via the unary
+//! code) but `read_bits` only indirectly through higher-level codes. These
+//! benchmarks measure the two methods in isolation so that changes to
+//! [`BufBitReader`] are visible without code-level overhead.
+//!
+//! Data is deterministic: unary values are sampled from the implied
+//! distribution p(x) = 2⁻⁽ˣ⁺¹⁾ with a fixed seed (as in `comparative`), and
+//! `read_bits` widths are uniform in 1..=32 with matching masked values.
+//! Before each benchmark is registered, one decode pass verifies a
+//! wrapping-sum checksum against the source values, so the run fails on any
+//! change that breaks decoding.
+//!
+//! ```bash
+//! cargo bench --bench bufbitreader --features implied
+//! ```
+
+mod common;
+
+use common::N;
+use common::data::gen_data;
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use dsi_bitstream::prelude::*;
+use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng};
+use std::hint::black_box;
+
+#[cfg(feature = "bench-u16")]
+type ReadWord = u16;
+#[cfg(all(feature = "bench-u64", not(feature = "bench-u16")))]
+type ReadWord = u64;
+#[cfg(not(any(feature = "bench-u16", feature = "bench-u64")))]
+type ReadWord = u32;
+
+/// Criterion group name, disambiguated by read-word size so that runs with
+/// different `bench-*` word features do not overwrite each other's results.
+#[cfg(feature = "bench-u16")]
+const GROUP: &str = "bufbitreader_u16";
+#[cfg(all(feature = "bench-u64", not(feature = "bench-u16")))]
+const GROUP: &str = "bufbitreader_u64";
+#[cfg(not(any(feature = "bench-u16", feature = "bench-u64")))]
+const GROUP: &str = "bufbitreader";
+
+/// Registers `read_unary` and `read_bits` benchmarks for one endianness.
+///
+/// Values are pre-encoded into a `Box<[u64]>` to guarantee alignment for
+/// reinterpretation as `&[ReadWord]` via `align_to`, as in `comparative`.
+macro_rules! bench_endian {
+    ($group:expr, $E:ty, $ename:literal, $unary_data:expr, $widths:expr, $values:expr) => {{
+        // read_unary
+        {
+            let data: &[u64] = $unary_data;
+            let encoded = {
+                let mut buffer: Box<[u64]> = vec![0u64; 10 * N].into_boxed_slice();
+                {
+                    let mut wr =
+                        BufBitWriter::<$E, _>::new(MemWordWriterSlice::<u64, _>::new(&mut *buffer));
+                    for &value in data {
+                        wr.write_unary(value).unwrap();
+                    }
+                }
+                buffer
+            };
+            // SAFETY: Box<[u64]> is aligned to 8 bytes, which satisfies
+            // alignment for ReadWord (u16/u32/u64).
+            let slice: &[ReadWord] = unsafe { encoded.align_to::<ReadWord>().1 };
+
+            // Correctness guard: one decode pass must reproduce the input sum.
+            let expected = data.iter().fold(0u64, |acc, &v| acc.wrapping_add(v));
+            let mut reader = BufBitReader::<$E, _>::new(MemWordReader::new(slice));
+            let mut sum = 0u64;
+            for _ in 0..data.len() {
+                sum = sum.wrapping_add(reader.read_unary().unwrap());
+            }
+            assert_eq!(sum, expected, "read_unary/{} checksum mismatch", $ename);
+
+            $group.bench_function(concat!("read_unary/", $ename), |b| {
+                b.iter(|| {
+                    let mut r = BufBitReader::<$E, _>::new(MemWordReader::new(slice));
+                    for _ in 0..N {
+                        black_box(r.read_unary().unwrap());
+                    }
+                });
+            });
+        }
+        // read_bits
+        {
+            let widths: &[usize] = $widths;
+            let values: &[u64] = $values;
+            let encoded = {
+                let mut buffer: Box<[u64]> = vec![0u64; 10 * N].into_boxed_slice();
+                {
+                    let mut wr =
+                        BufBitWriter::<$E, _>::new(MemWordWriterSlice::<u64, _>::new(&mut *buffer));
+                    for (&value, &n_bits) in values.iter().zip(widths) {
+                        wr.write_bits(value, n_bits).unwrap();
+                    }
+                }
+                buffer
+            };
+            // SAFETY: Box<[u64]> is aligned to 8 bytes, which satisfies
+            // alignment for ReadWord (u16/u32/u64).
+            let slice: &[ReadWord] = unsafe { encoded.align_to::<ReadWord>().1 };
+
+            // Correctness guard: one decode pass must reproduce the input sum.
+            let expected = values.iter().fold(0u64, |acc, &v| acc.wrapping_add(v));
+            let mut reader = BufBitReader::<$E, _>::new(MemWordReader::new(slice));
+            let mut sum = 0u64;
+            for &n_bits in widths {
+                sum = sum.wrapping_add(reader.read_bits(n_bits).unwrap());
+            }
+            assert_eq!(sum, expected, "read_bits/{} checksum mismatch", $ename);
+
+            $group.bench_function(concat!("read_bits/", $ename), |b| {
+                b.iter(|| {
+                    let mut r = BufBitReader::<$E, _>::new(MemWordReader::new(slice));
+                    for &n_bits in widths {
+                        black_box(r.read_bits(n_bits).unwrap());
+                    }
+                });
+            });
+        }
+    }};
+}
+
+fn bench_bufbitreader(c: &mut Criterion) {
+    #[cfg(target_os = "linux")]
+    common::utils::pin_to_core(5);
+
+    let mut group = c.benchmark_group(GROUP);
+    // Lossless: N = 1_000_000 fits u64 on all supported targets.
+    group.throughput(Throughput::Elements(u64::try_from(N).unwrap()));
+
+    // Unary values from the implied distribution p(x) = 2⁻⁽ˣ⁺¹⁾ (fixed seed
+    // inside gen_data); saturating_add keeps the length closure total.
+    let unary_data = gen_data(
+        |x| usize::try_from(x.saturating_add(1)).expect("unary code length fits usize"),
+        false,
+    );
+
+    // Widths uniform in 1..=32 (exercises both the buffered path and the
+    // refill path for u16/u32 read words) with values masked to their width.
+    let mut rng = SmallRng::seed_from_u64(0x0DD5_EED5);
+    let widths: Vec<usize> = (0..N).map(|_| rng.random_range(1..=32usize)).collect();
+    let values: Vec<u64> = widths
+        .iter()
+        .map(|&w| rng.random::<u64>() & (u64::MAX >> (64 - w)))
+        .collect();
+
+    bench_endian!(group, BE, "BE", &unary_data, &widths, &values);
+    bench_endian!(group, LE, "LE", &unary_data, &widths, &values);
+
+    group.finish();
+}
+
+criterion_group! {
+    name = bufbitreader;
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(std::time::Duration::from_millis(500))
+        .measurement_time(std::time::Duration::from_secs(2));
+    targets = bench_bufbitreader
+}
+
+criterion_main!(bufbitreader);

--- a/benches/bufbitreader_gamma.rs
+++ b/benches/bufbitreader_gamma.rs
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Tommaso Fontana
+ * SPDX-FileCopyrightText: 2026 Sebastiano Vigna
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+//! Composite Criterion benchmark for [`BufBitReader`]: `read_gamma` with
+//! default parameters (reading tables enabled), big and little endian.
+//!
+//! Kept in a separate binary from `bufbitreader` so that adding composite
+//! cases does not perturb the code layout of the four synthetic anchor
+//! cases (a 24% swing on `read_bits/BE` was observed when both case sets
+//! shared one binary).
+//!
+//! Gamma values are sampled from the implied distribution with a fixed seed
+//! (as in `comparative`); a wrapping-sum checksum is verified before timing.
+//!
+//! ```bash
+//! cargo bench --bench bufbitreader_gamma --features implied
+//! ```
+
+mod common;
+
+use common::N;
+use common::data::gen_gamma_data;
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use dsi_bitstream::prelude::*;
+use std::hint::black_box;
+
+#[cfg(feature = "bench-u16")]
+type ReadWord = u16;
+#[cfg(all(feature = "bench-u64", not(feature = "bench-u16")))]
+type ReadWord = u64;
+#[cfg(not(any(feature = "bench-u16", feature = "bench-u64")))]
+type ReadWord = u32;
+
+/// Registers the `read_gamma` benchmark for one endianness.
+///
+/// Values are pre-encoded into a `Box<[u64]>` to guarantee alignment for
+/// reinterpretation as `&[ReadWord]` via `align_to`, as in `comparative`.
+macro_rules! bench_endian {
+    ($group:expr, $E:ty, $ename:literal, $gamma_data:expr) => {{
+        let data: &[u64] = $gamma_data;
+        let encoded = {
+            let mut buffer: Box<[u64]> = vec![0u64; 10 * N].into_boxed_slice();
+            {
+                let mut wr =
+                    BufBitWriter::<$E, _>::new(MemWordWriterSlice::<u64, _>::new(&mut *buffer));
+                for &value in data {
+                    wr.write_gamma(value).unwrap();
+                }
+            }
+            buffer
+        };
+        // SAFETY: Box<[u64]> is aligned to 8 bytes, which satisfies
+        // alignment for ReadWord (u16/u32/u64).
+        let slice: &[ReadWord] = unsafe { encoded.align_to::<ReadWord>().1 };
+
+        // Correctness guard: one decode pass must reproduce the input sum.
+        let expected = data.iter().fold(0u64, |acc, &v| acc.wrapping_add(v));
+        let mut reader = BufBitReader::<$E, _>::new(MemWordReader::new(slice));
+        let mut sum = 0u64;
+        for _ in 0..data.len() {
+            sum = sum.wrapping_add(reader.read_gamma().unwrap());
+        }
+        assert_eq!(sum, expected, "read_gamma/{} checksum mismatch", $ename);
+
+        $group.bench_function(concat!("read_gamma/", $ename), |b| {
+            b.iter(|| {
+                let mut r = BufBitReader::<$E, _>::new(MemWordReader::new(slice));
+                for _ in 0..N {
+                    black_box(r.read_gamma().unwrap());
+                }
+            });
+        });
+    }};
+}
+
+fn bench_bufbitreader_gamma(c: &mut Criterion) {
+    #[cfg(target_os = "linux")]
+    common::utils::pin_to_core(5);
+
+    let mut group = c.benchmark_group("bufbitreader_gamma");
+    // Lossless: N = 1_000_000 fits u64 on all supported targets.
+    group.throughput(Throughput::Elements(u64::try_from(N).unwrap()));
+
+    // Gamma values from the implied distribution (fixed seed inside
+    // gen_data); decoded with default parameters (reading tables enabled).
+    let (_, gamma_data) = gen_gamma_data(false);
+
+    bench_endian!(group, BE, "BE", &gamma_data);
+    bench_endian!(group, LE, "LE", &gamma_data);
+
+    group.finish();
+}
+
+criterion_group! {
+    name = bufbitreader_gamma;
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(std::time::Duration::from_millis(500))
+        .measurement_time(std::time::Duration::from_secs(2));
+    targets = bench_bufbitreader_gamma
+}
+
+criterion_main!(bufbitreader_gamma);

--- a/benches/bufbitreader_wa.rs
+++ b/benches/bufbitreader_wa.rs
@@ -1,0 +1,138 @@
+/*
+ * Temporary evaluation bench: BufBitReader over a non-peekable WordAdapter
+ * (std::io::Cursor), so read_word_opt() returns None and the two-word top-up is
+ * compiled out. Mirrors benches/bufbitreader.rs workloads (u32 read word).
+ */
+
+mod common;
+
+use common::N;
+use common::data::gen_data;
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use dsi_bitstream::prelude::*;
+use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng};
+use std::hint::black_box;
+use std::io::Cursor;
+
+type ReadWord = u32;
+
+fn to_bytes(words: &[u64]) -> Vec<u8> {
+    words.iter().flat_map(|w| w.to_ne_bytes()).collect()
+}
+
+macro_rules! bench_endian_wa {
+    ($group:expr, $E:ty, $ename:literal, $unary_data:expr, $widths:expr, $values:expr) => {{
+        // read_unary
+        {
+            let data: &[u64] = $unary_data;
+            let encoded = {
+                let mut buffer: Box<[u64]> = vec![0u64; 10 * N].into_boxed_slice();
+                {
+                    let mut wr =
+                        BufBitWriter::<$E, _>::new(MemWordWriterSlice::<u64, _>::new(&mut *buffer));
+                    for &value in data {
+                        wr.write_unary(value).unwrap();
+                    }
+                }
+                buffer
+            };
+            let bytes = to_bytes(&encoded);
+
+            let expected = data.iter().fold(0u64, |acc, &v| acc.wrapping_add(v));
+            let mut reader = BufBitReader::<$E, _>::new(WordAdapter::<ReadWord, _>::new(
+                Cursor::new(bytes.as_slice()),
+            ));
+            let mut sum = 0u64;
+            for _ in 0..data.len() {
+                sum = sum.wrapping_add(reader.read_unary().unwrap());
+            }
+            assert_eq!(sum, expected, "read_unary/{} checksum mismatch", $ename);
+
+            $group.bench_function(concat!("read_unary/", $ename), |b| {
+                b.iter(|| {
+                    let mut r = BufBitReader::<$E, _>::new(WordAdapter::<ReadWord, _>::new(
+                        Cursor::new(bytes.as_slice()),
+                    ));
+                    for _ in 0..N {
+                        black_box(r.read_unary().unwrap());
+                    }
+                });
+            });
+        }
+        // read_bits
+        {
+            let widths: &[usize] = $widths;
+            let values: &[u64] = $values;
+            let encoded = {
+                let mut buffer: Box<[u64]> = vec![0u64; 10 * N].into_boxed_slice();
+                {
+                    let mut wr =
+                        BufBitWriter::<$E, _>::new(MemWordWriterSlice::<u64, _>::new(&mut *buffer));
+                    for (&value, &n_bits) in values.iter().zip(widths) {
+                        wr.write_bits(value, n_bits).unwrap();
+                    }
+                }
+                buffer
+            };
+            let bytes = to_bytes(&encoded);
+
+            let expected = values.iter().fold(0u64, |acc, &v| acc.wrapping_add(v));
+            let mut reader = BufBitReader::<$E, _>::new(WordAdapter::<ReadWord, _>::new(
+                Cursor::new(bytes.as_slice()),
+            ));
+            let mut sum = 0u64;
+            for &n_bits in widths {
+                sum = sum.wrapping_add(reader.read_bits(n_bits).unwrap());
+            }
+            assert_eq!(sum, expected, "read_bits/{} checksum mismatch", $ename);
+
+            $group.bench_function(concat!("read_bits/", $ename), |b| {
+                b.iter(|| {
+                    let mut r = BufBitReader::<$E, _>::new(WordAdapter::<ReadWord, _>::new(
+                        Cursor::new(bytes.as_slice()),
+                    ));
+                    for &n_bits in widths {
+                        black_box(r.read_bits(n_bits).unwrap());
+                    }
+                });
+            });
+        }
+    }};
+}
+
+fn bench_bufbitreader_wa(c: &mut Criterion) {
+    #[cfg(target_os = "linux")]
+    common::utils::pin_to_core(5);
+
+    let mut group = c.benchmark_group("bufbitreader_wa");
+    group.throughput(Throughput::Elements(u64::try_from(N).unwrap()));
+
+    let unary_data = gen_data(
+        |x| usize::try_from(x.saturating_add(1)).expect("unary code length fits usize"),
+        false,
+    );
+
+    let mut rng = SmallRng::seed_from_u64(0x0DD5_EED5);
+    let widths: Vec<usize> = (0..N).map(|_| rng.random_range(1..=32usize)).collect();
+    let values: Vec<u64> = widths
+        .iter()
+        .map(|&w| rng.random::<u64>() & (u64::MAX >> (64 - w)))
+        .collect();
+
+    bench_endian_wa!(group, BE, "BE", &unary_data, &widths, &values);
+    bench_endian_wa!(group, LE, "LE", &unary_data, &widths, &values);
+
+    group.finish();
+}
+
+criterion_group! {
+    name = bufbitreader_wa;
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(std::time::Duration::from_millis(500))
+        .measurement_time(std::time::Duration::from_secs(2));
+    targets = bench_bufbitreader_wa
+}
+
+criterion_main!(bufbitreader_wa);

--- a/benches/vbyte.rs
+++ b/benches/vbyte.rs
@@ -115,6 +115,7 @@ pub fn bench_byte_stream<C: ByteCode + WithName>(c: &mut Criterion) {
     }
 
     let s = gen_vbyte_data(GAMMA_DATA);
+
     c.bench_function(&format!("bytes/{}/write", C::name()), |b| {
         b.iter(|| {
             let mut w = std::io::Cursor::new(&mut v);
@@ -124,9 +125,21 @@ pub fn bench_byte_stream<C: ByteCode + WithName>(c: &mut Criterion) {
         })
     });
 
+    // Encode the read input into its own buffer so the read benchmark runs
+    // independently of the write benchmark: Criterion skips a filtered-out
+    // benchmark's body, so a read-only run (e.g. `-- read`) must not depend on
+    // the write closure having populated `v`.
+    let mut read_buf = <Vec<u8>>::with_capacity(CAPACITY);
+    {
+        let mut w = std::io::Cursor::new(&mut read_buf);
+        for &v in &s {
+            C::write(v, &mut w).unwrap();
+        }
+    }
+
     c.bench_function(&format!("bytes/{}/read", C::name()), |b| {
         b.iter(|| {
-            let mut r = std::io::Cursor::new(v.as_slice());
+            let mut r = std::io::Cursor::new(read_buf.as_slice());
             for _ in &s {
                 black_box(C::read(&mut r).unwrap());
             }
@@ -183,13 +196,23 @@ where
         })
     });
 
+    // Encode the read input into its own buffer so the read benchmark runs
+    // independently of the write benchmark (see `bench_byte_stream`).
+    let mut read_v = <Vec<u64>>::with_capacity(CAPACITY);
+    {
+        let mut w = BufBitWriter::<E, _>::new(MemWordWriterVec::new(&mut read_v));
+        for &v in &s {
+            C::write(v, &mut w).unwrap();
+        }
+        drop(w);
+    }
     // SAFETY: Vec<u64> is aligned to 8 bytes, which satisfies alignment for
     // u32.
-    let v = unsafe { v.align_to::<u32>().1 };
+    let read_words = unsafe { read_v.align_to::<u32>().1 };
 
     c.bench_function(&format!("bits/{}/{}/read", endian, C::name()), |b| {
         b.iter(|| {
-            let mut r = BufBitReader::<E, _>::new(MemWordReader::new(v));
+            let mut r = BufBitReader::<E, _>::new(MemWordReader::new(read_words));
             for _ in &s {
                 black_box(C::read(&mut r).unwrap());
             }

--- a/coverage.py
+++ b/coverage.py
@@ -16,11 +16,11 @@ FUZZING = True
 ROOT = os.path.dirname(os.path.abspath(__file__))
 target_folder = os.path.join(ROOT, "target")
 # Get info about the rust installation
-rustup_info = subprocess.check_output("rustup show", shell=True).decode()
+rustup_info = subprocess.check_output(["rustup", "show"]).decode()
 arch = re.findall(r"Default host: (.+)", rustup_info)[0]
 
 # Get where LLVM is installed
-sysroot = subprocess.check_output("rustc --print sysroot", shell=True).decode().strip()
+sysroot = subprocess.check_output(["rustc", "--print", "sysroot"]).decode().strip()
 llvm_path = os.path.join(sysroot, "lib", "rustlib", arch, "bin")
 
 # Check that people can read the doc
@@ -40,16 +40,14 @@ exec_files = []
 
 # Clean up the targets folder
 subprocess.check_call(
-    "cargo clean",
-    shell=True,
+    ["cargo", "clean"],
     cwd=ROOT,
 )
 # Create a folder for the test coverage
 os.makedirs(target_folder, exist_ok=True)
 
 out = subprocess.check_output(
-    "cargo test",
-    shell=True,
+    ["cargo", "test"],
     cwd=ROOT,
     stderr=subprocess.STDOUT,
     universal_newlines=True,
@@ -85,8 +83,7 @@ if FUZZING:
     # Get the list of fuzzing targets
     fuzz_targets = (
         subprocess.check_output(
-            "cargo fuzz list",
-            shell=True,
+            ["cargo", "fuzz", "list"],
             cwd=ROOT,
         )
         .decode()
@@ -95,8 +92,7 @@ if FUZZING:
     # Generate coverage for all the targets
     for fuzz_target in fuzz_targets:
         subprocess.check_call(
-            "cargo fuzz coverage {}".format(fuzz_target),
-            shell=True,
+            ["cargo", "fuzz", "coverage", fuzz_target],
             cwd=ROOT,
         )
 
@@ -113,25 +109,26 @@ if FUZZING:
 
 # Merge the coverages into a unique file
 subprocess.check_call(
-    "{}/llvm-profdata merge -sparse {} -o {}".format(
-        llvm_path,
-        " ".join(cov_files),
+    [
+        os.path.join(llvm_path, "llvm-profdata"),
+        "merge",
+        "-sparse",
+        *cov_files,
+        "-o",
         final_cov_path,
-    ),
-    shell=True,
+    ],
     cwd=ROOT,
 )
 
 # Create the report!
 subprocess.check_call(
-    (
-        "{}/llvm-cov report --Xdemangler=rustfilt --instr-profile={} "
-        "-ignore-filename-regex='.cargo' -object {}"
-    ).format(
-        llvm_path,
-        final_cov_path,
-        " -object ".join(exec_files),
-    ),
-    shell=True,
+    [
+        os.path.join(llvm_path, "llvm-cov"),
+        "report",
+        "--Xdemangler=rustfilt",
+        "--instr-profile=" + final_cov_path,
+        "-ignore-filename-regex=.cargo",
+        *(arg for f in exec_files for arg in ("-object", f)),
+    ],
     cwd=ROOT,
 )

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "*"
+libfuzzer-sys = "0.4"
 #libfuzzer-sys = { version = "*", package = "libafl_libfuzzer", features = ["introspection"], git = "https://github.com/AFLplusplus/LibAFL"}
 arbitrary = { version = "1", features = ["derive"] }
 

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -21,8 +21,10 @@ mkdir tmp
 unzip "tests/corpus/${TARGET}.zip" -d tmp
 # Merge and deduplicate the current corpus 
 cargo fuzz run ${TARGET} -- -merge=1 tmp fuzz/corpus/${TARGET}
-# Recompress
-zip tests/corpus/${TARGET}.zip tmp/*
+# Recompress from inside tmp so entries have no tmp/ prefix, into a fresh
+# archive (remove the old one first so stale entries are not kept)
+rm -f "tests/corpus/${TARGET}.zip"
+(cd tmp && zip -r "../tests/corpus/${TARGET}.zip" .)
 # Delete tmp folder
 rm -rfd tmp
 ```

--- a/python/bench_code_tables_read.py
+++ b/python/bench_code_tables_read.py
@@ -57,6 +57,9 @@ if (
     )
 
 read_word = positional[0]
+# u32 is the default word size (selected by enabling no word-size feature);
+# u16 and u64 have explicit features.
+word_feat = "" if read_word == "u32" else ",bench-%s" % read_word
 dist = positional[1] if len(positional) >= 2 else "univ"
 out_path = positional[2] if len(positional) >= 3 else None
 
@@ -114,7 +117,7 @@ print(
     file=sys.stderr,
 )
 
-features = "implied,bench-reads,bench-%s" % read_word
+features = "implied,bench-reads" + word_feat
 if dist == "univ":
     features += ",bench-univ"
 
@@ -147,7 +150,7 @@ for r in sorted(bench_results, key=lambda r: (r["code"], r["endian"], r["op"])):
     )
 
 # Also run delta_g no-table baseline
-features_dg = "implied,bench-reads,bench-%s,bench-delta-gamma" % read_word
+features_dg = "implied,bench-reads" + word_feat + ",bench-delta-gamma"
 if dist == "univ":
     features_dg += ",bench-univ"
 
@@ -221,7 +224,7 @@ for bits in range(1, min(16, max_table_bits) + 1):
         if os.path.isdir(table_dir):
             shutil.rmtree(table_dir)
 
-        features = "implied,bench-reads,bench-%s" % read_word
+        features = "implied,bench-reads" + word_feat
         if dist == "univ":
             features += ",bench-univ"
 
@@ -267,7 +270,7 @@ for bits in range(1, min(16, max_table_bits) + 1):
         # Remove stale Criterion results before delta_g run
         if os.path.isdir(table_dir):
             shutil.rmtree(table_dir)
-        features = "implied,bench-reads,bench-%s,bench-delta-gamma" % read_word
+        features = "implied,bench-reads" + word_feat + ",bench-delta-gamma"
         if dist == "univ":
             features += ",bench-univ"
         ratio_text_dg = run_cargo_bench(features, "^table/")

--- a/python/bench_code_tables_read.py
+++ b/python/bench_code_tables_read.py
@@ -70,19 +70,21 @@ if dist not in {"implied", "univ"}:
 word_bits = {"u16": 16, "u32": 32, "u64": 64}[read_word]
 max_table_bits = word_bits  # = PEEK_BITS for this read word
 
-# Build Criterion CLI options (without leading --, combined with regex after single --)
-criterion_opts_str = " ".join(criterion_opts)
-
 # Open output: file or stdout
 out = open(out_path, "w") if out_path else sys.stdout
 
 
-def run_cargo_bench(cmd):
+def run_cargo_bench(features, bench_filter):
     """Run cargo bench, letting Criterion output go to stdout and forwarding
-    compiler output to stderr.  Returns captured RATIO lines as a string."""
+    compiler output to stderr.  Returns captured RATIO lines as a string.
+    Uses an argv list (no shell) so caller-supplied Criterion options cannot be
+    interpreted as shell syntax."""
+    cmd = [
+        "cargo", "bench", "--bench", "tables",
+        "--features", features, "--", *criterion_opts, bench_filter,
+    ]
     process = subprocess.Popen(
         cmd,
-        shell=True,
         stdout=None,  # Criterion output → script's stdout
         stderr=subprocess.PIPE,  # capture for RATIO parsing + forwarding
         text=True,
@@ -121,10 +123,7 @@ no_table_dir = os.path.join(criterion_base, "no_table")
 if os.path.isdir(no_table_dir):
     shutil.rmtree(no_table_dir)
 
-ratio_text = run_cargo_bench(
-    "cargo bench --bench tables --features %s -- %s '^no_table/'"
-    % (features, criterion_opts_str)
-)
+ratio_text = run_cargo_bench(features, "^no_table/")
 
 bench_results = get_table_bench_results(criterion_base, group="no_table")
 
@@ -155,10 +154,7 @@ if dist == "univ":
 if os.path.isdir(no_table_dir):
     shutil.rmtree(no_table_dir)
 
-ratio_text_dg = run_cargo_bench(
-    "cargo bench --bench tables --features %s -- %s '^no_table/'"
-    % (features_dg, criterion_opts_str)
-)
+ratio_text_dg = run_cargo_bench(features_dg, "^no_table/")
 
 bench_results_dg = get_table_bench_results(criterion_base, group="no_table")
 for r in sorted(bench_results_dg, key=lambda r: (r["code"], r["endian"], r["op"])):
@@ -229,10 +225,7 @@ for bits in range(1, min(16, max_table_bits) + 1):
         if dist == "univ":
             features += ",bench-univ"
 
-        ratio_text = run_cargo_bench(
-            "cargo bench --bench tables --features %s -- %s '^table/'"
-            % (features, criterion_opts_str)
-        )
+        ratio_text = run_cargo_bench(features, "^table/")
 
         # Parse hit ratios
         ratios = parse_ratios_from_stderr(ratio_text)
@@ -277,10 +270,7 @@ for bits in range(1, min(16, max_table_bits) + 1):
         features = "implied,bench-reads,bench-%s,bench-delta-gamma" % read_word
         if dist == "univ":
             features += ",bench-univ"
-        ratio_text_dg = run_cargo_bench(
-            "cargo bench --bench tables --features %s -- %s '^table/'"
-            % (features, criterion_opts_str)
-        )
+        ratio_text_dg = run_cargo_bench(features, "^table/")
         ratios_dg = parse_ratios_from_stderr(ratio_text_dg)
         bench_results_dg = get_table_bench_results(criterion_base, group="table")
         for r in sorted(

--- a/python/bench_code_tables_write.py
+++ b/python/bench_code_tables_write.py
@@ -63,19 +63,22 @@ out_path = positional[2] if len(positional) >= 3 else None
 if dist not in {"implied", "univ"}:
     sys.exit("Distribution must be 'implied' or 'univ'")
 
-# Build Criterion CLI options (without leading --, combined with regex after single --)
-criterion_opts_str = " ".join(criterion_opts)
 
 # Open output: file or stdout
 out = open(out_path, "w") if out_path else sys.stdout
 
 
-def run_cargo_bench(cmd):
+def run_cargo_bench(features, bench_filter):
     """Run cargo bench, letting Criterion output go to stdout and forwarding
-    compiler output to stderr.  Returns captured RATIO lines as a string."""
+    compiler output to stderr.  Returns captured RATIO lines as a string.
+    Uses an argv list (no shell) so caller-supplied Criterion options cannot be
+    interpreted as shell syntax."""
+    cmd = [
+        "cargo", "bench", "--bench", "tables",
+        "--features", features, "--", *criterion_opts, bench_filter,
+    ]
     process = subprocess.Popen(
         cmd,
-        shell=True,
         stdout=None,  # Criterion output → script's stdout
         stderr=subprocess.PIPE,  # capture for RATIO parsing + forwarding
         text=True,
@@ -114,10 +117,7 @@ no_table_dir = os.path.join(criterion_base, "no_table")
 if os.path.isdir(no_table_dir):
     shutil.rmtree(no_table_dir)
 
-ratio_text = run_cargo_bench(
-    "cargo bench --bench tables --features %s -- %s '^no_table/'"
-    % (features, criterion_opts_str)
-)
+ratio_text = run_cargo_bench(features, "^no_table/")
 
 bench_results = get_table_bench_results(criterion_base, group="no_table")
 
@@ -146,10 +146,7 @@ if dist == "univ":
 if os.path.isdir(no_table_dir):
     shutil.rmtree(no_table_dir)
 
-ratio_text_dg = run_cargo_bench(
-    "cargo bench --bench tables --features %s -- %s '^no_table/'"
-    % (features_dg, criterion_opts_str)
-)
+ratio_text_dg = run_cargo_bench(features_dg, "^no_table/")
 
 bench_results_dg = get_table_bench_results(criterion_base, group="no_table")
 for r in sorted(bench_results_dg, key=lambda r: (r["code"], r["endian"], r["op"])):
@@ -221,10 +218,7 @@ for bits in range(1, 17):
         if dist == "univ":
             features += ",bench-univ"
 
-        ratio_text = run_cargo_bench(
-            "cargo bench --bench tables --features %s -- %s '^table/'"
-            % (features, criterion_opts_str)
-        )
+        ratio_text = run_cargo_bench(features, "^table/")
 
         # Parse hit ratios
         ratios = parse_ratios_from_stderr(ratio_text)
@@ -268,10 +262,7 @@ for bits in range(1, 17):
         if dist == "univ":
             features += ",bench-univ"
 
-        ratio_text_dg = run_cargo_bench(
-            "cargo bench --bench tables --features %s -- %s '^table/'"
-            % (features, criterion_opts_str)
-        )
+        ratio_text_dg = run_cargo_bench(features, "^table/")
 
         ratios_dg = parse_ratios_from_stderr(ratio_text_dg)
         bench_results_dg = get_table_bench_results(criterion_base, group="table")

--- a/python/bench_code_tables_write.py
+++ b/python/bench_code_tables_write.py
@@ -57,6 +57,9 @@ if (
     )
 
 write_word = positional[0]
+# u32 is the default word size (selected by enabling no word-size feature);
+# u16 and u64 have explicit features.
+word_feat = "" if write_word == "u32" else ",bench-%s" % write_word
 dist = positional[1] if len(positional) >= 2 else "univ"
 out_path = positional[2] if len(positional) >= 3 else None
 
@@ -108,7 +111,7 @@ print(
     file=sys.stderr,
 )
 
-features = "implied,bench-%s" % write_word
+features = "implied" + word_feat
 if dist == "univ":
     features += ",bench-univ"
 
@@ -139,7 +142,7 @@ for r in sorted(bench_results, key=lambda r: (r["code"], r["endian"], r["op"])):
     )
 
 # Also run delta_g no-table baseline
-features_dg = "implied,bench-delta-gamma,bench-%s" % write_word
+features_dg = "implied,bench-delta-gamma" + word_feat
 if dist == "univ":
     features_dg += ",bench-univ"
 
@@ -214,7 +217,7 @@ for bits in range(1, 17):
         if os.path.isdir(table_dir):
             shutil.rmtree(table_dir)
 
-        features = "implied,bench-%s" % write_word
+        features = "implied" + word_feat
         if dist == "univ":
             features += ",bench-univ"
 
@@ -258,7 +261,7 @@ for bits in range(1, 17):
         if os.path.isdir(table_dir):
             shutil.rmtree(table_dir)
 
-        features = "implied,bench-delta-gamma,bench-%s" % write_word
+        features = "implied,bench-delta-gamma" + word_feat
         if dist == "univ":
             features += ",bench-univ"
 

--- a/python/gen_code_tables.py
+++ b/python/gen_code_tables.py
@@ -606,7 +606,7 @@ def gen_delta(read_bits, write_max_val, len_max_val=None, merged_table=False):
 /// Reads from the decoding table.
 ///
 /// Returns `(len_with_flag, value_or_gamma)` where:
-/// - If len_with_flag >= 0: complete code, value_or_gamma is decoded value, len_with_flag is code length
+/// - If len_with_flag > 0: complete code, value_or_gamma is decoded value, len_with_flag is code length
 /// - If len_with_flag < 0: partial code (gamma decoded), value_or_gamma is gamma_len, (len_with_flag & 0x7F) is gamma code length
 /// - If len_with_flag = 0: no valid decoding (gamma not decoded)
 ///
@@ -1121,7 +1121,7 @@ def gen_omega(read_bits, write_max_val, len_max_val=None, merged_table=False):
 /// Reads from the decoding table.
 ///
 /// Returns `(len_with_flag, value)` where:
-/// - If len_with_flag >= 0: complete code, value is decoded value, len_with_flag is code length
+/// - If len_with_flag > 0: complete code, value is decoded value, len_with_flag is code length
 /// - If len_with_flag < 0: partial code, value is partial_n, (len_with_flag & 0x7F) is partial_len
 /// - If len_with_flag = 0: no valid decoding (cannot occur with >= 2 bit tables)
 ///
@@ -1491,7 +1491,7 @@ def gen_pi(read_bits, write_max_val, len_max_val=None, k=2, merged_table=False):
 /// Reads from the decoding table.
 ///
 /// Returns `(len_with_flag, value_or_lambda)` where:
-/// - If len_with_flag >= 0: complete code, value_or_lambda is decoded value, len_with_flag is code length
+/// - If len_with_flag > 0: complete code, value_or_lambda is decoded value, len_with_flag is code length
 /// - If len_with_flag < 0: partial code (rice decoded), value_or_lambda is lambda, (len_with_flag & 0x7F) is rice code length
 /// - If len_with_flag = 0: no valid decoding (rice not decoded)
 ///

--- a/src/codes/delta.rs
+++ b/src/codes/delta.rs
@@ -12,7 +12,7 @@
 //! [γ](crate::codes::gamma) code of ⌊log₂(*n* + 1)⌋ and the binary
 //! representation of *n* + 1 with the most significant bit removed.
 //!
-//! The implied distribution of the δ code is ≈ 1/2*x*(log *x*)².
+//! The implied distribution of the δ code is ≈ 1/(2 *x* (log *x*)²).
 //!
 //! The `USE_DELTA_TABLE` parameter enables or disables the use of pre-computed
 //! tables for decoding δ codes, and the `USE_GAMMA_TABLE` parameter enables or

--- a/src/codes/delta_tables.rs
+++ b/src/codes/delta_tables.rs
@@ -12,7 +12,7 @@ pub const WRITE_MAX: u64 = 255;
 /// Reads from the decoding table.
 ///
 /// Returns `(len_with_flag, value_or_gamma)` where:
-/// - If len_with_flag >= 0: complete code, value_or_gamma is decoded value, len_with_flag is code length
+/// - If len_with_flag > 0: complete code, value_or_gamma is decoded value, len_with_flag is code length
 /// - If len_with_flag < 0: partial code (gamma decoded), value_or_gamma is gamma_len, (len_with_flag & 0x7F) is gamma code length
 /// - If len_with_flag = 0: no valid decoding (gamma not decoded)
 ///
@@ -35,7 +35,7 @@ pub fn read_table_le<B: BitRead<LE>>(backend: &mut B) -> (i8, u64) {
 /// Reads from the decoding table.
 ///
 /// Returns `(len_with_flag, value_or_gamma)` where:
-/// - If len_with_flag >= 0: complete code, value_or_gamma is decoded value, len_with_flag is code length
+/// - If len_with_flag > 0: complete code, value_or_gamma is decoded value, len_with_flag is code length
 /// - If len_with_flag < 0: partial code (gamma decoded), value_or_gamma is gamma_len, (len_with_flag & 0x7F) is gamma code length
 /// - If len_with_flag = 0: no valid decoding (gamma not decoded)
 ///

--- a/src/codes/gamma.rs
+++ b/src/codes/gamma.rs
@@ -12,7 +12,7 @@
 //! ⌊log₂(*n* + 1)⌋ and of the binary representation of *n* + 1 with the most
 //! significant bit removed.
 //!
-//! The implied distribution of the γ code is ≈ 1/2*x*².
+//! The implied distribution of the γ code is ≈ 1/(2 *x*²).
 //!
 //! The `USE_TABLE` parameter enables or disables the use of pre-computed tables
 //! for decoding.

--- a/src/codes/mod.rs
+++ b/src/codes/mod.rs
@@ -36,16 +36,25 @@
 //! write the number [`u64::MAX`] because of overflow issues, which could be
 //! avoided with tests, but at the price of a significant performance drop.
 //!
-//! For the same reason, reading methods assume well-formed input: decoding a
-//! corrupted or malicious bit stream may return arbitrary values and, in debug
-//! builds, may panic because of overflow checks. If you need to decode
-//! untrusted data, you must validate the decoded values.
-//!
 //! The traits ending with `Param` make it possible to specify parameters—for
 //! example, whether to use decoding tables. Usually, one would instead pull
 //! into scope non-parametric traits such as [`GammaRead`] and [`GammaWrite`],
 //! for which defaults are provided using the mechanism described in the
 //! [`params`] module.
+//!
+//! # Decoding untrusted input
+//!
+//! For performance, the decoders assume a well-formed stream produced by the
+//! corresponding encoder: some derived codeword lengths are guarded only by a
+//! `debug_assert!`, and other reachable arithmetic (shifts, `quotient * b`) is
+//! unchecked. A malformed or adversarial bit stream (for example one read
+//! through [`BufBitReader`](crate::impls::BufBitReader) over an untrusted
+//! source) may therefore panic or return an incorrect value -- depending on the
+//! code and on the `debug-assertions`/`overflow-checks` settings -- instead of
+//! returning an error. The [VByte](vbyte) decoders are the exception: they
+//! bound the codeword length. Validate untrusted input, or restrict decoding to
+//! a trusted producer, before use; the [`Codes`](crate::dispatch::Codes)
+//! descriptor is itself validated when parsed or deserialized.
 //!
 //! # Big-endian vs. little-endian
 //!

--- a/src/codes/omega_tables.rs
+++ b/src/codes/omega_tables.rs
@@ -20,7 +20,7 @@ pub const WRITE_MAX: u64 = 63;
 /// Reads from the decoding table.
 ///
 /// Returns `(len_with_flag, value)` where:
-/// - If len_with_flag >= 0: complete code, value is decoded value, len_with_flag is code length
+/// - If len_with_flag > 0: complete code, value is decoded value, len_with_flag is code length
 /// - If len_with_flag < 0: partial code, value is partial_n, (len_with_flag & 0x7F) is partial_len
 /// - If len_with_flag = 0: no valid decoding (cannot occur with >= 2 bit tables)
 ///
@@ -44,7 +44,7 @@ pub fn read_table_le<B: BitRead<LE>>(backend: &mut B) -> (i8, u64) {
 /// Reads from the decoding table.
 ///
 /// Returns `(len_with_flag, value)` where:
-/// - If len_with_flag >= 0: complete code, value is decoded value, len_with_flag is code length
+/// - If len_with_flag > 0: complete code, value is decoded value, len_with_flag is code length
 /// - If len_with_flag < 0: partial code, value is partial_n, (len_with_flag & 0x7F) is partial_len
 /// - If len_with_flag = 0: no valid decoding (cannot occur with >= 2 bit tables)
 ///

--- a/src/codes/params.rs
+++ b/src/codes/params.rs
@@ -32,13 +32,19 @@
 //! blanket implementations for parameterless traits contained in
 //! this module.
 //!
-//! However, you can also create new selector types implementing
-//! [`ReadParams`]/[`WriteParams`] and write blanket implementations
-//! for the bitstream readers and writers in [`crate::impls`] where
-//! `RP`/`WP` is set to your selector types. Then, by specifying
-//! your type as value of the parameter `RP`/`WP` when creating such
-//! readers and writers you will use automatically your blanket
-//! implementations instead of the ones provided by this module.
+//! You can also define a new selector type implementing
+//! [`ReadParams`]/[`WriteParams`] and, *within this crate*, provide blanket
+//! implementations of the parameterless code traits for the bitstream readers
+//! and writers in [`crate::impls`] with `RP`/`WP` set to that type; a reader or
+//! writer using it then picks up those implementations instead of the ones
+//! provided here. Both the read and write blanket implementations in this
+//! module are provided specifically for
+//! [`DefaultReadParams`]/[`DefaultWriteParams`], so a different selector does
+//! not silently inherit the defaults. Note that, because both the code traits
+//! and the bitstream types are defined in this crate, Rust's orphan rules
+//! prevent a downstream crate from adding such implementations for its own
+//! selector type; a fully custom selector must therefore be added within this
+//! crate.
 //!
 //! Note that the default implementations provided by this module are targeted at
 //! `u32` read words and `u64` write words. If you use different word sizes,
@@ -221,8 +227,8 @@ impl WriteParams for DefaultWriteParams {}
 
 macro_rules! impl_default_write_codes {
     ($($endianness:ident),*) => {$(
-        impl<WR: WordWrite, WP: WriteParams> GammaWrite<$endianness>
-            for BufBitWriter<$endianness, WR, WP>
+        impl<WR: WordWrite> GammaWrite<$endianness>
+            for BufBitWriter<$endianness, WR, DefaultWriteParams>
             where u64: PrimitiveNumberAs<WR::Word>,
         {
             #[inline(always)]
@@ -231,8 +237,8 @@ macro_rules! impl_default_write_codes {
             }
         }
 
-        impl<WR: WordWrite, WP: WriteParams> DeltaWrite<$endianness>
-            for BufBitWriter<$endianness, WR, WP>
+        impl<WR: WordWrite> DeltaWrite<$endianness>
+            for BufBitWriter<$endianness, WR, DefaultWriteParams>
             where u64: PrimitiveNumberAs<WR::Word>,
         {
             #[inline(always)]
@@ -241,8 +247,8 @@ macro_rules! impl_default_write_codes {
             }
         }
 
-        impl<WR: WordWrite, WP: WriteParams> OmegaWrite<$endianness>
-            for BufBitWriter<$endianness, WR, WP>
+        impl<WR: WordWrite> OmegaWrite<$endianness>
+            for BufBitWriter<$endianness, WR, DefaultWriteParams>
             where u64: PrimitiveNumberAs<WR::Word>,
         {
             #[inline(always)]
@@ -251,8 +257,8 @@ macro_rules! impl_default_write_codes {
             }
         }
 
-        impl<WR: WordWrite, WP: WriteParams> ZetaWrite<$endianness>
-            for BufBitWriter<$endianness, WR, WP>
+        impl<WR: WordWrite> ZetaWrite<$endianness>
+            for BufBitWriter<$endianness, WR, DefaultWriteParams>
             where u64: PrimitiveNumberAs<WR::Word>,
         {
             #[inline(always)]
@@ -266,8 +272,8 @@ macro_rules! impl_default_write_codes {
             }
         }
 
-        impl<WR: WordWrite, WP: WriteParams> PiWrite<$endianness>
-            for BufBitWriter<$endianness, WR, WP>
+        impl<WR: WordWrite> PiWrite<$endianness>
+            for BufBitWriter<$endianness, WR, DefaultWriteParams>
             where u64: PrimitiveNumberAs<WR::Word>,
         {
             #[inline(always)]

--- a/src/codes/pi_tables.rs
+++ b/src/codes/pi_tables.rs
@@ -14,7 +14,7 @@ pub const K: usize = 2;
 /// Reads from the decoding table.
 ///
 /// Returns `(len_with_flag, value_or_lambda)` where:
-/// - If len_with_flag >= 0: complete code, value_or_lambda is decoded value, len_with_flag is code length
+/// - If len_with_flag > 0: complete code, value_or_lambda is decoded value, len_with_flag is code length
 /// - If len_with_flag < 0: partial code (rice decoded), value_or_lambda is lambda, (len_with_flag & 0x7F) is rice code length
 /// - If len_with_flag = 0: no valid decoding (rice not decoded)
 ///
@@ -37,7 +37,7 @@ pub fn read_table_le<B: BitRead<LE>>(backend: &mut B) -> (i8, u64) {
 /// Reads from the decoding table.
 ///
 /// Returns `(len_with_flag, value_or_lambda)` where:
-/// - If len_with_flag >= 0: complete code, value_or_lambda is decoded value, len_with_flag is code length
+/// - If len_with_flag > 0: complete code, value_or_lambda is decoded value, len_with_flag is code length
 /// - If len_with_flag < 0: partial code (rice decoded), value_or_lambda is lambda, (len_with_flag & 0x7F) is rice code length
 /// - If len_with_flag = 0: no valid decoding (rice not decoded)
 ///

--- a/src/codes/vbyte.rs
+++ b/src/codes/vbyte.rs
@@ -39,10 +39,11 @@
 //! little-endian codes, the first byte contains the lowest (least significant)
 //! bits.
 //!
-//! The advantage of the big-endian variant is that is lexicographical, that is,
-//! comparing lexicographically a stream of encoded natural numbers will give
-//! the same results as comparing lexicographically the encoded numbers, much
-//! like it happens for [UTF-8 encoding](https://en.wikipedia.org/wiki/UTF-8).
+//! In the big-endian variant the first byte holds the most significant bits.
+//! Note that the *complete* codes implemented here (which drop the redundant
+//! encodings) are not lexicographic across code-length boundaries: for example
+//! 16511 encodes to `[0xff, 0x7f]`, but the larger 16512 encodes to
+//! `[0x80, 0x80, 0x00]`, which compares byte-wise smaller.
 //!
 //! ## Completeness
 //!

--- a/src/codes/vbyte.rs
+++ b/src/codes/vbyte.rs
@@ -135,6 +135,9 @@ pub const fn bit_len_vbyte(n: u64) -> usize {
     8 * byte_len_vbyte(n)
 }
 
+/// Maximum number of bytes in the variable-length byte code of a `u64`.
+const MAX_VBYTE_LEN: usize = byte_len_vbyte(u64::MAX);
+
 /// Trait for reading big-endian variable-length byte codes.
 ///
 /// Note that the endianness of the code is independent
@@ -156,10 +159,20 @@ impl<E: Endianness, B: BitRead<E>> VByteBeRead<E> for B {
     fn read_vbyte_be(&mut self) -> Result<u64, Self::Error> {
         let mut byte = self.read_bits(8)?;
         let mut value = byte & 0x7F;
-        while (byte >> 7) != 0 {
-            value += 1;
+        // A u64 vbyte code is at most MAX_VBYTE_LEN bytes; stop there so a
+        // malformed continuation bit on the last byte cannot read into the
+        // following data (BE) or shift by >= 64 (LE). BitRead has no
+        // malformed-input error channel (the backend Error may be Infallible),
+        // so a non-canonical overlong code yields a bounded value rather than a
+        // panic, a desync, or an unbounded read.
+        let mut read = 1;
+        while (byte >> 7) != 0 && read < MAX_VBYTE_LEN {
+            // wrapping: a malformed overlong code may carry a value past u64;
+            // BitRead has no error channel, so wrap (bounded) instead of panicking.
+            value = value.wrapping_add(1);
             byte = self.read_bits(8)?;
             value = (value << 7) | (byte & 0x7F);
+            read += 1;
         }
         Ok(value)
     }
@@ -168,16 +181,20 @@ impl<E: Endianness, B: BitRead<E>> VByteBeRead<E> for B {
 impl<E: Endianness, B: BitRead<E>> VByteLeRead<E> for B {
     #[inline(always)]
     fn read_vbyte_le(&mut self) -> Result<u64, Self::Error> {
-        let mut result = 0;
+        let mut result: u64 = 0;
         let mut shift = 0;
+        // See read_vbyte_be: bound the code to MAX_VBYTE_LEN bytes so a
+        // malformed continuation bit cannot push shift to >= 64.
+        let mut read = 0;
         loop {
             let byte = self.read_bits(8)?;
-            result += (byte & 0x7F) << shift;
-            if (byte >> 7) == 0 {
+            result = result.wrapping_add((byte & 0x7F) << shift);
+            read += 1;
+            if (byte >> 7) == 0 || read == MAX_VBYTE_LEN {
                 break;
             }
             shift += 7;
-            result += 1 << shift;
+            result = result.wrapping_add(1 << shift);
         }
         Ok(result)
     }
@@ -297,6 +314,16 @@ pub fn vbyte_write_le<W: std::io::Write>(mut n: u64, writer: &mut W) -> std::io:
     Ok(len)
 }
 
+/// Error for a byte-stream vbyte code that is longer than, or encodes a value
+/// outside, the `u64` range.
+#[cfg(feature = "std")]
+fn overlong_vbyte() -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        "vbyte code too long or out of range for a u64",
+    )
+}
+
 /// Decode a natural number from a byte stream using variable-length byte codes.
 ///
 /// This method just delegates to the correct endianness-specific method.
@@ -316,15 +343,22 @@ pub fn vbyte_read<E: Endianness, R: std::io::Read>(reader: &mut R) -> std::io::R
 #[cfg(feature = "std")]
 pub fn vbyte_read_be<R: std::io::Read>(reader: &mut R) -> std::io::Result<u64> {
     let mut buf = [0u8; 1];
-    let mut value: u64;
     reader.read_exact(&mut buf)?;
-    value = (buf[0] & 0x7F) as u64;
+    // Accumulate in u128 so a malformed high-payload code cannot overflow
+    // silently; a code longer than MAX_VBYTE_LEN bytes or a value exceeding
+    // u64 is rejected (this reader has an io error channel).
+    let mut value = u128::from(buf[0] & 0x7F);
+    let mut read = 1;
     while (buf[0] >> 7) != 0 {
+        if read == MAX_VBYTE_LEN {
+            return Err(overlong_vbyte());
+        }
         value += 1;
         reader.read_exact(&mut buf)?;
-        value = (value << 7) | ((buf[0] & 0x7F) as u64);
+        value = (value << 7) | u128::from(buf[0] & 0x7F);
+        read += 1;
     }
-    Ok(value)
+    u64::try_from(value).map_err(|_| overlong_vbyte())
 }
 
 /// Decode a natural number from a little-endian byte stream using
@@ -332,20 +366,27 @@ pub fn vbyte_read_be<R: std::io::Read>(reader: &mut R) -> std::io::Result<u64> {
 #[inline(always)]
 #[cfg(feature = "std")]
 pub fn vbyte_read_le<R: std::io::Read>(reader: &mut R) -> std::io::Result<u64> {
-    let mut result = 0;
+    // Accumulate in u128 so a malformed high-payload code cannot overflow
+    // silently; see vbyte_read_be.
+    let mut result: u128 = 0;
     let mut shift = 0;
     let mut buffer = [0; 1];
+    let mut read = 0;
     loop {
         reader.read_exact(&mut buffer)?;
         let byte = buffer[0];
-        result += ((byte & 0x7F) as u64) << shift;
+        result += u128::from(byte & 0x7F) << shift;
+        read += 1;
         if (byte >> 7) == 0 {
             break;
         }
+        if read == MAX_VBYTE_LEN {
+            return Err(overlong_vbyte());
+        }
         shift += 7;
-        result += 1 << shift;
+        result += 1u128 << shift;
     }
-    Ok(result)
+    u64::try_from(result).map_err(|_| overlong_vbyte())
 }
 
 #[cfg(test)]
@@ -418,4 +459,35 @@ mod tests {
 
     impl_tests!(test_vbytes_be, BE);
     impl_tests!(test_vbytes_le, LE);
+
+    #[test]
+    fn io_reader_rejects_overlong() {
+        // 11 continuation bytes: longer than any u64 vbyte code.
+        let data = [0xFFu8; 11];
+        assert!(vbyte_read_be(&mut std::io::Cursor::new(&data[..])).is_err());
+        assert!(vbyte_read_le(&mut std::io::Cursor::new(&data[..])).is_err());
+    }
+
+    #[test]
+    fn bit_reader_is_bounded_on_overlong() {
+        use crate::prelude::{BufBitReader, MemWordReader};
+        // Every byte has its continuation bit set; without the length cap the
+        // little-endian reader would shift by >= 64 (panic in debug), and the
+        // big-endian reader would read far past a valid code.
+        let words = [u64::MAX; 4];
+        let mut rb = BufBitReader::<BE, _>::new(MemWordReader::new_inf(&words));
+        let _ = rb.read_vbyte_be().unwrap();
+        let mut rl = BufBitReader::<LE, _>::new(MemWordReader::new_inf(&words));
+        let _ = rl.read_vbyte_le().unwrap();
+    }
+
+    #[test]
+    fn io_reader_rejects_value_over_u64() {
+        // A 10-byte code (within the byte cap) whose payload encodes a value
+        // far above u64::MAX: the terminal byte clears the continuation bit, so
+        // only the u128 range check catches it.
+        let data = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F];
+        assert!(vbyte_read_be(&mut std::io::Cursor::new(&data[..])).is_err());
+        assert!(vbyte_read_le(&mut std::io::Cursor::new(&data[..])).is_err());
+    }
 }

--- a/src/dispatch/codes.rs
+++ b/src/dispatch/codes.rs
@@ -327,6 +327,9 @@ pub enum CodeError {
     ParseError(core::num::ParseIntError),
     /// Unknown code name. Uses a fixed-size array instead of `String` for `no_std` compatibility.
     UnknownCode([u8; 32]),
+    /// A parameter is outside the valid range for its code (for example
+    /// `Golomb(0)`, `Zeta(0)`, or a shift parameter `>= 64`).
+    InvalidParameter([u8; 32]),
 }
 impl core::error::Error for CodeError {}
 impl core::fmt::Display for CodeError {
@@ -335,6 +338,16 @@ impl core::fmt::Display for CodeError {
             CodeError::ParseError(e) => write!(f, "parse error: {}", e),
             CodeError::UnknownCode(s) => {
                 write!(f, "unknown code: ")?;
+                for c in s {
+                    if *c == 0 {
+                        break;
+                    }
+                    write!(f, "{}", *c as char)?;
+                }
+                Ok(())
+            }
+            CodeError::InvalidParameter(s) => {
+                write!(f, "invalid parameter for code: ")?;
                 for c in s {
                     if *c == 0 {
                         break;
@@ -391,36 +404,59 @@ impl core::str::FromStr for Codes {
             "VByteLe" => Ok(Codes::VByteLe),
 
             _ => {
-                let mut parts = s.split('(');
-                let name = parts
-                    .next()
+                // Strict grammar: exactly `Name(param)` with `param` a single
+                // integer and nothing after the closing parenthesis. The former
+                // `split` accepted trailing/incomplete text (e.g. `Zeta(3)x`).
+                let inner = s
+                    .strip_suffix(')')
                     .ok_or_else(|| CodeError::UnknownCode(array_format_error(s)))?;
-                let k = parts
-                    .next()
-                    .ok_or_else(|| CodeError::UnknownCode(array_format_error(s)))?
-                    .split(')')
-                    .next()
+                let (name, param) = inner
+                    .split_once('(')
                     .ok_or_else(|| CodeError::UnknownCode(array_format_error(s)))?;
+                if param.contains('(') || param.contains(')') {
+                    return Err(CodeError::UnknownCode(array_format_error(s)));
+                }
+                let invalid = || CodeError::InvalidParameter(array_format_error(s));
                 match name {
+                    // zeta is defined for k in [1, 64).
                     "Zeta" => {
-                        let k: usize = k.parse()?;
-                        // ζ codes are defined only for k >= 1
-                        if k == 0 {
-                            return Err(CodeError::UnknownCode(array_format_error(s)));
+                        let k: usize = param.parse()?;
+                        if k == 0 || k >= 64 {
+                            return Err(invalid());
                         }
                         Ok(Codes::Zeta(k))
                     }
-                    "Pi" => Ok(Codes::Pi(k.parse()?)),
+                    // pi, exponential Golomb and Rice shift by their parameter,
+                    // so it must stay below 64.
+                    "Pi" => {
+                        let k: usize = param.parse()?;
+                        if k >= 64 {
+                            return Err(invalid());
+                        }
+                        Ok(Codes::Pi(k))
+                    }
+                    "ExpGolomb" => {
+                        let k: usize = param.parse()?;
+                        if k >= 64 {
+                            return Err(invalid());
+                        }
+                        Ok(Codes::ExpGolomb(k))
+                    }
+                    "Rice" => {
+                        let k: usize = param.parse()?;
+                        if k >= 64 {
+                            return Err(invalid());
+                        }
+                        Ok(Codes::Rice(k))
+                    }
+                    // Golomb divides by its modulus, which must be positive.
                     "Golomb" => {
-                        let b: u64 = k.parse()?;
-                        // Golomb codes are defined only for b >= 1
+                        let b: u64 = param.parse()?;
                         if b == 0 {
-                            return Err(CodeError::UnknownCode(array_format_error(s)));
+                            return Err(invalid());
                         }
                         Ok(Codes::Golomb(b))
                     }
-                    "ExpGolomb" => Ok(Codes::ExpGolomb(k.parse()?)),
-                    "Rice" => Ok(Codes::Rice(k.parse()?)),
                     _ => Err(CodeError::UnknownCode(array_format_error(name))),
                 }
             }
@@ -498,5 +534,46 @@ impl<E: Endianness, CW: CodesWrite<E> + ?Sized> StaticCodeWrite<E, CW> for Minim
 impl CodeLen for MinimalBinary {
     fn len(&self, n: u64) -> usize {
         len_minimal_binary(n, self.0)
+    }
+}
+
+#[cfg(test)]
+mod parse_tests {
+    use super::Codes;
+    use core::str::FromStr;
+
+    #[test]
+    fn parses_valid_parameterized_codes() {
+        assert_eq!(Codes::from_str("Unary").unwrap(), Codes::Unary);
+        assert_eq!(Codes::from_str("Zeta(3)").unwrap(), Codes::Zeta(3));
+        assert_eq!(Codes::from_str("Pi(2)").unwrap(), Codes::Pi(2));
+        assert_eq!(Codes::from_str("Golomb(7)").unwrap(), Codes::Golomb(7));
+        assert_eq!(
+            Codes::from_str("ExpGolomb(0)").unwrap(),
+            Codes::ExpGolomb(0)
+        );
+        assert_eq!(Codes::from_str("Rice(0)").unwrap(), Codes::Rice(0));
+        assert_eq!(Codes::from_str("Rice(63)").unwrap(), Codes::Rice(63));
+    }
+
+    #[test]
+    fn rejects_out_of_range_parameters() {
+        // These previously deserialized into values that panic on first use
+        // (divide-by-zero) or shift by >= 64.
+        assert!(Codes::from_str("Golomb(0)").is_err());
+        assert!(Codes::from_str("Zeta(0)").is_err());
+        assert!(Codes::from_str("Zeta(64)").is_err());
+        assert!(Codes::from_str("Rice(64)").is_err());
+        assert!(Codes::from_str("Pi(64)").is_err());
+        assert!(Codes::from_str("ExpGolomb(64)").is_err());
+    }
+
+    #[test]
+    fn rejects_malformed_grammar() {
+        assert!(Codes::from_str("Zeta(3").is_err());
+        assert!(Codes::from_str("Zeta(3)x").is_err());
+        assert!(Codes::from_str("Zeta(3)(4)").is_err());
+        assert!(Codes::from_str("Zeta()").is_err());
+        assert!(Codes::from_str("Nope(1)").is_err());
     }
 }

--- a/src/impls/bit_reader.rs
+++ b/src/impls/bit_reader.rs
@@ -267,40 +267,30 @@ impl<WR: WordRead<Word = u64> + WordSeek<Error = <WR as WordRead>::Error>, RP: R
 impl<WR: WordRead<Word = u64> + WordSeek<Error = <WR as WordRead>::Error>, RP: ReadParams>
     std::io::Read for BitReader<LE, WR, RP>
 {
+    /// Note that this implementation does not use `Ok(0)` to signal
+    /// stream exhaustion (an empty `buf` still yields `Ok(0)` as required):
+    /// the underlying [`WordRead`] error type cannot distinguish end of
+    /// stream from a backend failure, so reading past the last available
+    /// byte fails with
+    /// [`std::io::ErrorKind::UnexpectedEof`] rather than silently reporting
+    /// end of file (which would make a genuine backend error look like a
+    /// clean EOF). To read a stream of known length to its end, bound the
+    /// reader with [`std::io::Read::take`] or use exact-length reads.
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let mut read = 0;
-        let mut iter = buf.chunks_exact_mut(8);
-
-        for chunk in &mut iter {
-            match self.read_bits(64) {
-                Ok(word) => {
-                    chunk.copy_from_slice(&word.to_le_bytes());
-                    read += 8;
+        // Read byte by byte so the returned count reflects exactly the bytes
+        // produced (read_bits(64) is not atomic on a narrow-word backend near
+        // EOF); the reader's endianness handles bit order.
+        for (i, slot) in buf.iter_mut().enumerate() {
+            match self.read_bits(8) {
+                Ok(byte) => {
+                    debug_assert!(byte < 256, "read_bits(8) yields at most 8 bits");
+                    *slot = byte as u8;
                 }
-                // If we read some bytes, return them; the error will
-                // resurface at the next call
-                Err(_) if read > 0 => return Ok(read),
-                Err(e) => {
-                    return Err(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e));
-                }
+                Err(_) if i > 0 => return Ok(i),
+                Err(_) => return Err(std::io::ErrorKind::UnexpectedEof.into()),
             }
         }
-
-        let rem = iter.into_remainder();
-        if !rem.is_empty() {
-            match self.read_bits(rem.len() * 8) {
-                Ok(word) => {
-                    rem.copy_from_slice(&word.to_le_bytes()[..rem.len()]);
-                    read += rem.len();
-                }
-                Err(_) if read > 0 => return Ok(read),
-                Err(e) => {
-                    return Err(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e));
-                }
-            }
-        }
-
-        Ok(read)
+        Ok(buf.len())
     }
 }
 
@@ -308,39 +298,20 @@ impl<WR: WordRead<Word = u64> + WordSeek<Error = <WR as WordRead>::Error>, RP: R
 impl<WR: WordRead<Word = u64> + WordSeek<Error = <WR as WordRead>::Error>, RP: ReadParams>
     std::io::Read for BitReader<BE, WR, RP>
 {
+    /// Does not use `Ok(0)` to signal stream exhaustion; see the
+    /// little-endian implementation.
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let mut read = 0;
-        let mut iter = buf.chunks_exact_mut(8);
-
-        for chunk in &mut iter {
-            match self.read_bits(64) {
-                Ok(word) => {
-                    chunk.copy_from_slice(&word.to_be_bytes());
-                    read += 8;
+        // See the little-endian impl.
+        for (i, slot) in buf.iter_mut().enumerate() {
+            match self.read_bits(8) {
+                Ok(byte) => {
+                    debug_assert!(byte < 256, "read_bits(8) yields at most 8 bits");
+                    *slot = byte as u8;
                 }
-                // If we read some bytes, return them; the error will
-                // resurface at the next call
-                Err(_) if read > 0 => return Ok(read),
-                Err(e) => {
-                    return Err(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e));
-                }
+                Err(_) if i > 0 => return Ok(i),
+                Err(_) => return Err(std::io::ErrorKind::UnexpectedEof.into()),
             }
         }
-
-        let rem = iter.into_remainder();
-        if !rem.is_empty() {
-            match self.read_bits(rem.len() * 8) {
-                Ok(word) => {
-                    rem.copy_from_slice(&word.to_be_bytes()[8 - rem.len()..]);
-                    read += rem.len();
-                }
-                Err(_) if read > 0 => return Ok(read),
-                Err(e) => {
-                    return Err(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e));
-                }
-            }
-        }
-
-        Ok(read)
+        Ok(buf.len())
     }
 }

--- a/src/impls/buf_bit_reader.rs
+++ b/src/impls/buf_bit_reader.rs
@@ -172,6 +172,44 @@ where
         self.buffer |= new_word << (Self::BUFFER_BITS - self.bits_in_buffer);
         Ok(())
     }
+    /// Single-word refill for 64-bit words (128-bit buffer), specialized so
+    /// that the result and the pre-top-up buffer, which both live entirely
+    /// in the high 64 bits of the buffer, are computed in u64 arithmetic
+    /// (no cross-half 128-bit shifts).
+    ///
+    /// Must be called only when `WORD_BITS == 64`, with `w` the word read
+    /// for this request and `bits_in_buffer < num_bits <= WORD_BITS`.
+    #[inline(always)]
+    fn read_bits_refill_word64(
+        &mut self,
+        num_bits: usize,
+        w: WR::Word,
+    ) -> Result<u64, <WR as WordRead>::Error> {
+        debug_assert!(Self::WORD_BITS == 64);
+        let bits = self.bits_in_buffer;
+        // High half of buffer | word placed right below the buffered bits.
+        // Shifts valid: bits < num_bits <= WORD_BITS = 64, and num_bits >= 1
+        // because the in-buffer fast path handled num_bits <= bits.
+        let virt_hi: u64 = (self.buffer >> Self::WORD_BITS).as_to::<u64>() | (w.as_u64() >> bits);
+        let result = virt_hi >> (Self::WORD_BITS - num_bits);
+        // The remaining low WORD_BITS - (num_bits - bits) bits of the word,
+        // placed at the top of the high half; double shift as
+        // num_bits - bits may equal WORD_BITS.
+        let hi = (w << (num_bits - bits - 1)) << 1_u32;
+        let mut buffer = hi.as_double() << Self::WORD_BITS;
+        let mut new_bits = bits + Self::WORD_BITS - num_bits;
+        // Top up with a second word if available: new_bits < WORD_BITS here,
+        // so there is always room and the buffer stays short of full. The
+        // atomic optional read never consumes past the end of the stream.
+        if let Some(w2) = self.backend.read_word_opt() {
+            // Shifts valid: WORD_BITS and new_bits are < BUFFER_BITS.
+            buffer |= (w2.to_be().as_double() << Self::WORD_BITS) >> new_bits;
+            new_bits += Self::WORD_BITS;
+        }
+        self.buffer = buffer;
+        self.bits_in_buffer = new_bits;
+        Ok(result)
+    }
 }
 
 impl<WR: WordRead, RP: ReadParams> BitRead<BE> for BufBitReader<BE, WR, RP>
@@ -220,6 +258,51 @@ where
             self.buffer <<= num_bits;
             return Ok(result);
         }
+        // Single-word refill path: past the test above, a request of at most
+        // WORD_BITS bits always consumes exactly one word, which we can
+        // compose with the buffer without the loop and the branches of the
+        // general path below.
+        if num_bits <= Self::WORD_BITS {
+            let bits = self.bits_in_buffer;
+            // The word is required in any case, so no peek is needed.
+            let w = self.backend.read_word()?.to_be();
+            // For 64-bit words (128-bit buffer), the result and the
+            // pre-top-up buffer both live entirely in the high 64 bits of
+            // the buffer, so the specialized helper uses u64 arithmetic,
+            // avoiding cross-half 128-bit shifts. The branch is resolved at
+            // compile time; the helper keeps the dead branch's MIR footprint
+            // to one statement so that inlining decisions for narrow-word
+            // readers are unaffected.
+            if Self::WORD_BITS == 64 {
+                return self.read_bits_refill_word64(num_bits, w);
+            }
+            // Place the word right below the buffered bits; the word fits
+            // entirely because bits < num_bits <= WORD_BITS, and both
+            // shifts are valid as WORD_BITS and bits are < BUFFER_BITS.
+            let placed = (w.as_double() << Self::WORD_BITS) >> bits;
+            let virt = self.buffer | placed;
+            // Valid right shift, even when num_bits is zero
+            let result: u64 = (virt >> (Self::BUFFER_BITS - num_bits - 1) >> 1_u32).as_to();
+            // The new buffer comes from the placed word alone: bits <
+            // num_bits, so all buffered bits are consumed and
+            // `self.buffer << num_bits` would be zero; dropping the `|` from
+            // this computation shortens the loop-carried dependency chain.
+            let mut buffer = placed << num_bits;
+            let mut new_bits = bits + Self::WORD_BITS - num_bits;
+            // Top up with a second word if available: new_bits < WORD_BITS
+            // here, so there is always room and the buffer stays short of
+            // full. This halves the number of refills, making the in-buffer
+            // test above more predictable. The atomic optional read never
+            // consumes past the end of the stream.
+            if let Some(w2) = self.backend.read_word_opt() {
+                // Shifts valid: WORD_BITS and new_bits are < BUFFER_BITS.
+                buffer |= (w2.to_be().as_double() << Self::WORD_BITS) >> new_bits;
+                new_bits += Self::WORD_BITS;
+            }
+            self.buffer = buffer;
+            self.bits_in_buffer = new_bits;
+            return Ok(result);
+        }
 
         let mut result: u64 =
             (self.buffer >> (Self::BUFFER_BITS - 1 - self.bits_in_buffer) >> 1_u8).as_to();
@@ -257,7 +340,16 @@ where
 
         // if we encountered a 1 in the bits_in_buffer we can return
         if zeros < self.bits_in_buffer {
-            self.buffer = self.buffer << zeros << 1;
+            // zeros + 1 <= bits_in_buffer < BUFFER_BITS, so both forms are
+            // always valid. On 128-bit buffers a single merged shift avoids a
+            // second synthesized wide shift (measured -13% on u64-word
+            // read_unary); on 64-bit buffers the two-step shift measured
+            // slightly faster, so each width keeps its best form (const-folded).
+            if Self::BUFFER_BITS > 64 {
+                self.buffer <<= zeros + 1;
+            } else {
+                self.buffer = self.buffer << zeros << 1;
+            }
             self.bits_in_buffer -= zeros + 1;
             return Ok(zeros as u64);
         }
@@ -269,8 +361,19 @@ where
 
             if new_word != WR::Word::ZERO {
                 let zeros: usize = new_word.leading_zeros() as _;
-                self.buffer = new_word.as_double() << (Self::WORD_BITS + zeros) << 1;
-                self.bits_in_buffer = Self::WORD_BITS - zeros - 1;
+                let mut buffer = new_word.as_double() << (Self::WORD_BITS + zeros) << 1;
+                let mut new_bits = Self::WORD_BITS - zeros - 1;
+                // Top up with a second word if available: new_bits <
+                // WORD_BITS here, so there is always room and the buffer
+                // stays short of full. The atomic optional read never
+                // consumes past the end of the stream (see read_bits).
+                if let Some(w2) = self.backend.read_word_opt() {
+                    // Shifts valid: WORD_BITS and new_bits are < BUFFER_BITS.
+                    buffer |= (w2.to_be().as_double() << Self::WORD_BITS) >> new_bits;
+                    new_bits += Self::WORD_BITS;
+                }
+                self.buffer = buffer;
+                self.bits_in_buffer = new_bits;
                 return Ok(result + zeros as u64);
             }
             result += Self::WORD_BITS as u64;
@@ -460,6 +563,39 @@ where
             return Ok(result);
         }
 
+        // Single-word refill path: see the big-endian implementation for the
+        // invariants.
+        if num_bits <= Self::WORD_BITS {
+            let bits = self.bits_in_buffer;
+            // The word is required in any case, so no peek is needed.
+            let w = self.backend.read_word()?.to_le();
+            // Shift valid: bits < num_bits <= WORD_BITS < BUFFER_BITS,
+            // and the word fits entirely above the buffered bits.
+            let virt = self.buffer | (w.as_double() << bits);
+            // Extract the low num_bits (num_bits <= WORD_BITS < BUFFER_BITS)
+            let result: u64 = (virt & ((BB::<WR>::ONE << num_bits) - BB::<WR>::ONE)).as_to();
+            // The new buffer comes from the word alone: bits < num_bits, so
+            // all buffered bits are consumed and `buffer >> num_bits` would
+            // be zero. Keeping `virt` off this computation shortens the
+            // loop-carried dependency chain. Shift valid: 1 <= num_bits -
+            // bits <= WORD_BITS < BUFFER_BITS.
+            let mut buffer = w.as_double() >> (num_bits - bits);
+            let mut new_bits = bits + Self::WORD_BITS - num_bits;
+            // Top up with a second word if available: new_bits < WORD_BITS
+            // here, so there is always room and the buffer stays short of
+            // full. This halves the number of refills, making the in-buffer
+            // test above more predictable. The atomic optional read never
+            // consumes past the end of the stream.
+            if let Some(w2) = self.backend.read_word_opt() {
+                // Shift valid: new_bits < WORD_BITS <= BUFFER_BITS - WORD_BITS.
+                buffer |= w2.to_le().as_double() << new_bits;
+                new_bits += Self::WORD_BITS;
+            }
+            self.buffer = buffer;
+            self.bits_in_buffer = new_bits;
+            return Ok(result);
+        }
+
         let mut result: u64 = self.buffer.as_to();
         let mut bits_in_res = self.bits_in_buffer;
 
@@ -498,7 +634,12 @@ where
 
         // if we encountered a 1 in the bits_in_buffer we can return
         if zeros < self.bits_in_buffer {
-            self.buffer = self.buffer >> zeros >> 1;
+            // See the big-endian implementation for the shift-form choice.
+            if Self::BUFFER_BITS > 64 {
+                self.buffer >>= zeros + 1;
+            } else {
+                self.buffer = self.buffer >> zeros >> 1;
+            }
             self.bits_in_buffer -= zeros + 1;
             return Ok(zeros as u64);
         }
@@ -510,8 +651,19 @@ where
 
             if new_word != WR::Word::ZERO {
                 let zeros: usize = new_word.trailing_zeros() as _;
-                self.buffer = new_word.as_double() >> zeros >> 1;
-                self.bits_in_buffer = Self::WORD_BITS - zeros - 1;
+                let mut buffer = new_word.as_double() >> zeros >> 1;
+                let mut new_bits = Self::WORD_BITS - zeros - 1;
+                // Top up with a second word if available: new_bits <
+                // WORD_BITS here, so there is always room and the buffer
+                // stays short of full. The atomic optional read never
+                // consumes past the end of the stream (see read_bits).
+                if let Some(w2) = self.backend.read_word_opt() {
+                    // Shift valid: new_bits < WORD_BITS <= BUFFER_BITS - WORD_BITS.
+                    buffer |= w2.to_le().as_double() << new_bits;
+                    new_bits += Self::WORD_BITS;
+                }
+                self.buffer = buffer;
+                self.bits_in_buffer = new_bits;
                 return Ok(result + zeros as u64);
             }
             result += Self::WORD_BITS as u64;
@@ -723,6 +875,48 @@ mod tests {
     use crate::prelude::{MemWordReader, MemWordWriterVec};
     use core::error::Error;
     use std::io::Read;
+    /// On a strict (finite) backend, the two-word top-up must consume a word
+    /// only when one is available, and the read-and-consume must be atomic:
+    /// every bit of the stream is read back exactly once, the reader works
+    /// through the exact end of the data, and only then errors.
+    #[test]
+    fn test_topup_at_end_of_stream() {
+        macro_rules! check {
+            ($E:ty, $to:ident) => {{
+                let words: [u32; 3] = [0xA1B2_C3D4_u32.$to(), 0x1596_37D8_u32.$to(), !0];
+                let mut r = BufBitReader::<$E, _>::new(MemWordReader::new(&words));
+                let mut all: Vec<u64> = Vec::new();
+                // 20 + 40 + 20 + 16 = 96 bits = exactly three words; the
+                // first and third reads cross a word boundary and top up.
+                for n in [20, 40, 20, 16] {
+                    all.push(r.read_bits(n).unwrap());
+                }
+                // The stream is exhausted: no word was consumed early, none
+                // was lost, and the next read fails.
+                assert!(r.read_bits(1).is_err());
+                // The same bits read in one 64-bit and one 32-bit piece must
+                // reassemble identically.
+                let mut r2 = BufBitReader::<$E, _>::new(MemWordReader::new(&words));
+                let a = r2.read_bits(64).unwrap();
+                let b = r2.read_bits(32).unwrap();
+                assert!(r2.read_bits(1).is_err());
+                if TypeId::of::<$E>() == TypeId::of::<BE>() {
+                    assert_eq!(all[0], a >> 44);
+                    assert_eq!(all[1], (a >> 4) & ((1 << 40) - 1));
+                    assert_eq!(all[2], ((a & 0xF) << 16) | (b >> 16));
+                    assert_eq!(all[3], b & 0xFFFF);
+                } else {
+                    assert_eq!(all[0], a & ((1 << 20) - 1));
+                    assert_eq!(all[1], (a >> 20) & ((1 << 40) - 1));
+                    assert_eq!(all[2], (a >> 60) | ((b & 0xFFFF) << 4));
+                    assert_eq!(all[3], b >> 16);
+                }
+            }};
+        }
+        use core::any::TypeId;
+        check!(BE, to_be);
+        check!(LE, to_le);
+    }
 
     #[test]
     fn test_read() -> std::io::Result<()> {

--- a/src/impls/buf_bit_reader.rs
+++ b/src/impls/buf_bit_reader.rs
@@ -29,8 +29,9 @@ type BB<WR> = <<WR as WordRead>::Word as DoubleType>::DoubleType;
 ///
 /// The peek word is equal to the bit buffer. The value returned
 /// by [`peek_bits`](crate::traits::BitRead::peek_bits) contains at least as
-/// many bits as the word size plus one (extended with zeros beyond end of
-/// stream).
+/// many bits as the word size (extended with zeros beyond end of stream):
+/// a peek is served by at most one refill, so only one word of peekable
+/// bits can be guaranteed.
 ///
 /// The convenience functions [`from_path`] and [`from_file`] (requiring the
 /// `std` feature) create a [`BufBitReader`] around a buffered file reader.
@@ -226,7 +227,7 @@ where
     #[inline(always)]
     fn peek_bits(&mut self, n_bits: usize) -> Result<Self::PeekWord, Self::Error> {
         debug_assert!(n_bits > 0);
-        debug_assert!(n_bits <= Self::PeekWord::BITS as usize);
+        debug_assert!(n_bits <= Self::PEEK_BITS);
 
         // A peek can do at most one refill, otherwise we might lose data
         if n_bits > self.bits_in_buffer {
@@ -530,7 +531,7 @@ where
     #[inline(always)]
     fn peek_bits(&mut self, n_bits: usize) -> Result<Self::PeekWord, Self::Error> {
         debug_assert!(n_bits > 0);
-        debug_assert!(n_bits <= Self::PeekWord::BITS as usize);
+        debug_assert!(n_bits <= Self::PEEK_BITS);
 
         // A peek can do at most one refill, otherwise we might lose data
         if n_bits > self.bits_in_buffer {
@@ -889,6 +890,56 @@ mod tests {
         use core::any::TypeId;
         check!(BE, to_be);
         check!(LE, to_le);
+    }
+
+    /// The maximum documented peek (`PEEK_BITS` = one word) must be served
+    /// by a single refill from a completely empty buffer.
+    #[test]
+    fn test_peek_max_from_empty_buffer() {
+        macro_rules! check {
+            ($W:ty) => {{
+                const BITS: usize = <$W>::BITS as usize;
+                let words: [$W; 4] = [!0, 0, 0, 0];
+                let mut r = BufBitReader::<BE, _>::new(MemWordReader::new(&words));
+                assert_eq!(
+                    <BufBitReader<BE, MemWordReader<$W, &[$W; 4]>> as BitRead<BE>>::PEEK_BITS,
+                    BITS
+                );
+                assert_eq!(
+                    r.peek_bits(BITS).unwrap().as_to::<u64>(),
+                    (!0 as $W).as_to::<u64>()
+                );
+                let mut r = BufBitReader::<LE, _>::new(MemWordReader::new(&words));
+                assert_eq!(
+                    r.peek_bits(BITS).unwrap().as_to::<u64>(),
+                    (!0 as $W).as_to::<u64>()
+                );
+            }};
+        }
+        check!(u16);
+        check!(u32);
+        check!(u64);
+    }
+
+    /// Peeking more than `PEEK_BITS` bits violates the documented contract;
+    /// in debug builds the tightened assertion catches it.
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic]
+    fn test_peek_beyond_peek_bits_panics_be() {
+        let words: [u32; 4] = [0; 4];
+        let mut r = BufBitReader::<BE, _>::new(MemWordReader::new(&words));
+        let _ = r.peek_bits(33);
+    }
+
+    /// See [`test_peek_beyond_peek_bits_panics_be`].
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic]
+    fn test_peek_beyond_peek_bits_panics_le() {
+        let words: [u32; 4] = [0; 4];
+        let mut r = BufBitReader::<LE, _>::new(MemWordReader::new(&words));
+        let _ = r.peek_bits(33);
     }
 
     #[test]

--- a/src/impls/buf_bit_reader.rs
+++ b/src/impls/buf_bit_reader.rs
@@ -789,40 +789,32 @@ impl<WR: WordRead, RP: ReadParams> std::io::Read for BufBitReader<LE, WR, RP>
 where
     WR::Word: DoubleType,
 {
+    /// Note that this implementation does not use `Ok(0)` to signal
+    /// stream exhaustion (an empty `buf` still yields `Ok(0)` as required):
+    /// the underlying [`WordRead`] error type cannot distinguish end of
+    /// stream from a backend failure, so reading past the last available
+    /// byte fails with
+    /// [`std::io::ErrorKind::UnexpectedEof`] rather than silently reporting
+    /// end of file (which would make a genuine backend error look like a
+    /// clean EOF). To read a stream of known length to its end, bound the
+    /// reader with [`std::io::Read::take`] or use exact-length reads.
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let mut read = 0;
-        let mut iter = buf.chunks_exact_mut(8);
-
-        for chunk in &mut iter {
-            match self.read_bits(64) {
-                Ok(word) => {
-                    chunk.copy_from_slice(&word.to_le_bytes());
-                    read += 8;
+        // Read byte by byte so the returned count reflects exactly the bytes
+        // produced. A chunked read_bits(64) is not atomic on a narrow-word
+        // backend: it can consume backend words and then error near EOF, which
+        // would lose readable bytes. The reader's endianness handles bit order,
+        // so this reproduces the same bytes as the byte-oriented writer.
+        for (i, slot) in buf.iter_mut().enumerate() {
+            match self.read_bits(8) {
+                Ok(byte) => {
+                    debug_assert!(byte < 256, "read_bits(8) yields at most 8 bits");
+                    *slot = byte as u8;
                 }
-                // If we read some bytes, return them; the error will
-                // resurface at the next call
-                Err(_) if read > 0 => return Ok(read),
-                Err(e) => {
-                    return Err(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e));
-                }
+                Err(_) if i > 0 => return Ok(i),
+                Err(_) => return Err(std::io::ErrorKind::UnexpectedEof.into()),
             }
         }
-
-        let rem = iter.into_remainder();
-        if !rem.is_empty() {
-            match self.read_bits(rem.len() * 8) {
-                Ok(word) => {
-                    rem.copy_from_slice(&word.to_le_bytes()[..rem.len()]);
-                    read += rem.len();
-                }
-                Err(_) if read > 0 => return Ok(read),
-                Err(e) => {
-                    return Err(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e));
-                }
-            }
-        }
-
-        Ok(read)
+        Ok(buf.len())
     }
 }
 
@@ -831,40 +823,21 @@ impl<WR: WordRead, RP: ReadParams> std::io::Read for BufBitReader<BE, WR, RP>
 where
     WR::Word: DoubleType,
 {
+    /// Does not use `Ok(0)` to signal stream exhaustion; see the
+    /// little-endian implementation.
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let mut read = 0;
-        let mut iter = buf.chunks_exact_mut(8);
-
-        for chunk in &mut iter {
-            match self.read_bits(64) {
-                Ok(word) => {
-                    chunk.copy_from_slice(&word.to_be_bytes());
-                    read += 8;
+        // See the little-endian impl.
+        for (i, slot) in buf.iter_mut().enumerate() {
+            match self.read_bits(8) {
+                Ok(byte) => {
+                    debug_assert!(byte < 256, "read_bits(8) yields at most 8 bits");
+                    *slot = byte as u8;
                 }
-                // If we read some bytes, return them; the error will
-                // resurface at the next call
-                Err(_) if read > 0 => return Ok(read),
-                Err(e) => {
-                    return Err(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e));
-                }
+                Err(_) if i > 0 => return Ok(i),
+                Err(_) => return Err(std::io::ErrorKind::UnexpectedEof.into()),
             }
         }
-
-        let rem = iter.into_remainder();
-        if !rem.is_empty() {
-            match self.read_bits(rem.len() * 8) {
-                Ok(word) => {
-                    rem.copy_from_slice(&word.to_be_bytes()[8 - rem.len()..]);
-                    read += rem.len();
-                }
-                Err(_) if read > 0 => return Ok(read),
-                Err(e) => {
-                    return Err(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e));
-                }
-            }
-        }
-
-        Ok(read)
+        Ok(buf.len())
     }
 }
 

--- a/src/impls/buf_bit_writer.rs
+++ b/src/impls/buf_bit_writer.rs
@@ -479,30 +479,31 @@ where
 {
     #[inline(always)]
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        let mut iter = buf.chunks_exact(8);
-
-        for word in &mut iter {
-            self.write_bits(u64::from_be_bytes(word.try_into().unwrap()), 64)
-                .map_err(|_| std::io::Error::other("could not write bits to stream"))?;
-        }
-
-        let rem = iter.remainder();
-        if !rem.is_empty() {
-            let mut word = 0;
-            let bits = rem.len() * 8;
-            for byte in rem.iter() {
-                word <<= 8;
-                word |= *byte as u64;
+        // Write byte by byte. Snapshot the buffer state around each byte so a
+        // backend failure leaves the writer exactly as it was before that byte:
+        // the returned partial count is then safe for write_all to retry, and
+        // the writer is not left corrupted. Confined to the io adapter; the hot
+        // write_bits path is unchanged. The endianness handles bit order.
+        for (i, &byte) in buf.iter().enumerate() {
+            let saved = (self.buffer, self.space_left_in_buffer);
+            match self.write_bits(u64::from(byte), 8) {
+                Ok(_) => {}
+                Err(e) => {
+                    self.buffer = saved.0;
+                    self.space_left_in_buffer = saved.1;
+                    return if i > 0 {
+                        Ok(i)
+                    } else {
+                        Err(std::io::Error::other(e))
+                    };
+                }
             }
-            self.write_bits(word, bits)
-                .map_err(|_| std::io::Error::other("could not write bits to stream"))?;
         }
-
         Ok(buf.len())
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        flush_be(self).map_err(|_| std::io::Error::other("could not flush bits to stream"))?;
+        flush_be(self).map_err(std::io::Error::other)?;
         Ok(())
     }
 }
@@ -514,30 +515,27 @@ where
 {
     #[inline(always)]
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        let mut iter = buf.chunks_exact(8);
-
-        for word in &mut iter {
-            self.write_bits(u64::from_le_bytes(word.try_into().unwrap()), 64)
-                .map_err(|_| std::io::Error::other("could not write bits to stream"))?;
-        }
-
-        let rem = iter.remainder();
-        if !rem.is_empty() {
-            let mut word = 0;
-            let bits = rem.len() * 8;
-            for byte in rem.iter().rev() {
-                word <<= 8;
-                word |= *byte as u64;
+        // See the big-endian impl.
+        for (i, &byte) in buf.iter().enumerate() {
+            let saved = (self.buffer, self.space_left_in_buffer);
+            match self.write_bits(u64::from(byte), 8) {
+                Ok(_) => {}
+                Err(e) => {
+                    self.buffer = saved.0;
+                    self.space_left_in_buffer = saved.1;
+                    return if i > 0 {
+                        Ok(i)
+                    } else {
+                        Err(std::io::Error::other(e))
+                    };
+                }
             }
-            self.write_bits(word, bits)
-                .map_err(|_| std::io::Error::other("could not write bits to stream"))?;
         }
-
         Ok(buf.len())
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        flush_le(self).map_err(|_| std::io::Error::other("could not flush bits to stream"))?;
+        flush_le(self).map_err(std::io::Error::other)?;
         Ok(())
     }
 }

--- a/src/impls/mem_word_reader.rs
+++ b/src/impls/mem_word_reader.rs
@@ -103,6 +103,20 @@ impl<W: Word, B: AsRef<[W]>> WordRead for MemWordReader<W, B, true> {
         self.word_index += 1;
         Ok(res)
     }
+
+    #[inline(always)]
+    fn read_word_opt(&mut self) -> Option<W> {
+        // Consistently with read_word, reading past the end returns zero,
+        // and the position may grow past the end.
+        let word = self
+            .data
+            .as_ref()
+            .get(self.word_index)
+            .copied()
+            .unwrap_or(W::ZERO);
+        self.word_index = self.word_index.saturating_add(1);
+        Some(word)
+    }
 }
 
 impl<W: Word, B: AsRef<[W]>> WordRead for MemWordReader<W, B, false> {
@@ -121,6 +135,15 @@ impl<W: Word, B: AsRef<[W]>> WordRead for MemWordReader<W, B, false> {
 
         self.word_index += 1;
         Ok(*res)
+    }
+
+    #[inline(always)]
+    fn read_word_opt(&mut self) -> Option<W> {
+        let word = self.data.as_ref().get(self.word_index).copied();
+        if word.is_some() {
+            self.word_index += 1;
+        }
+        word
     }
 }
 

--- a/src/traits/bits.rs
+++ b/src/traits/bits.rs
@@ -77,7 +77,7 @@ pub trait BitRead<E: Endianness> {
     fn read_bits(&mut self, num_bits: usize) -> Result<u64, Self::Error>;
 
     /// Peeks at `n` bits without advancing the stream position.
-    /// `n` must be nonzero, and at most `Self::PeekWord::BITS`.
+    /// `n` must be nonzero, and at most `Self::PEEK_BITS`.
     fn peek_bits(&mut self, n: usize) -> Result<Self::PeekWord, Self::Error>;
 
     /// Skip `n` bits from the stream.

--- a/src/traits/words.rs
+++ b/src/traits/words.rs
@@ -89,6 +89,28 @@ pub trait WordRead {
 
     /// Reads a word and advances the current position.
     fn read_word(&mut self) -> Result<Self::Word, Self::Error>;
+
+    /// Reads and consumes the next word if the backend can determine cheaply
+    /// that one is available, returning `None` otherwise (in particular, at
+    /// the end of the stream, or when availability cannot be determined
+    /// without blocking or performing I/O).
+    ///
+    /// `None` leaves the current position unchanged, and this method never
+    /// fails: read-and-consume is a single atomic operation, so callers can
+    /// combine it with buffered state without an error path in between (a
+    /// separate peek-then-skip pair would allow the skip to fail after the
+    /// caller committed to consuming the word).
+    ///
+    /// The default implementation returns `None`. Backends with cheap random
+    /// access (e.g., [`MemWordReader`](crate::impls::MemWordReader)) should
+    /// override this method: readers such as
+    /// [`BufBitReader`](crate::impls::BufBitReader) use it to provide
+    /// branch-free read paths, falling back to
+    /// [`read_word`](WordRead::read_word) when `None` is returned.
+    #[inline(always)]
+    fn read_word_opt(&mut self) -> Option<Self::Word> {
+        None
+    }
 }
 
 /// Sequential, streaming word-by-word writes.

--- a/src/utils/count.rs
+++ b/src/utils/count.rs
@@ -21,8 +21,10 @@ use mem_dbg::{MemDbg, MemSize};
 #[cfg_attr(feature = "mem_dbg", derive(MemDbg, MemSize))]
 pub struct CountBitWriter<E: Endianness, BW: BitWrite<E>, const PRINT: bool = false> {
     bit_write: BW,
-    /// The number of bits written so far on the underlying [`BitWrite`].
-    pub bits_written: usize,
+    /// The number of bits written so far on the underlying [`BitWrite`]. Uses
+    /// u64 (bit positions are u64) so it does not wrap after 2^32 bits on
+    /// 32-bit targets. Increments widen usize losslessly (usize <= 64 bits).
+    pub bits_written: u64,
     _marker: core::marker::PhantomData<E>,
 }
 
@@ -50,7 +52,7 @@ impl<E: Endianness, BW: BitWrite<E>, const PRINT: bool> BitWrite<E>
 
     fn write_bits(&mut self, value: u64, num_bits: usize) -> Result<usize, Self::Error> {
         self.bit_write.write_bits(value, num_bits).inspect(|x| {
-            self.bits_written += *x;
+            self.bits_written += *x as u64;
             if PRINT {
                 #[cfg(feature = "std")]
                 eprintln!(
@@ -63,7 +65,7 @@ impl<E: Endianness, BW: BitWrite<E>, const PRINT: bool> BitWrite<E>
 
     fn write_unary(&mut self, n: u64) -> Result<usize, Self::Error> {
         self.bit_write.write_unary(n).inspect(|x| {
-            self.bits_written += *x;
+            self.bits_written += *x as u64;
             if PRINT {
                 #[cfg(feature = "std")]
                 eprintln!("write_unary({}) = {} (total = {})", n, x, self.bits_written);
@@ -89,7 +91,7 @@ impl<E: Endianness, BW: BitWrite<E> + GammaWrite<E>, const PRINT: bool> GammaWri
 {
     fn write_gamma(&mut self, n: u64) -> Result<usize, BW::Error> {
         self.bit_write.write_gamma(n).inspect(|x| {
-            self.bits_written += *x;
+            self.bits_written += *x as u64;
             if PRINT {
                 #[cfg(feature = "std")]
                 eprintln!("write_gamma({}) = {} (total = {})", n, x, self.bits_written);
@@ -103,7 +105,7 @@ impl<E: Endianness, BW: BitWrite<E> + DeltaWrite<E>, const PRINT: bool> DeltaWri
 {
     fn write_delta(&mut self, n: u64) -> Result<usize, BW::Error> {
         self.bit_write.write_delta(n).inspect(|x| {
-            self.bits_written += *x;
+            self.bits_written += *x as u64;
             if PRINT {
                 #[cfg(feature = "std")]
                 eprintln!("write_delta({}) = {} (total = {})", n, x, self.bits_written);
@@ -117,7 +119,7 @@ impl<E: Endianness, BW: BitWrite<E> + ZetaWrite<E>, const PRINT: bool> ZetaWrite
 {
     fn write_zeta(&mut self, n: u64, k: usize) -> Result<usize, BW::Error> {
         self.bit_write.write_zeta(n, k).inspect(|x| {
-            self.bits_written += *x;
+            self.bits_written += *x as u64;
             if PRINT {
                 #[cfg(feature = "std")]
                 eprintln!(
@@ -130,7 +132,7 @@ impl<E: Endianness, BW: BitWrite<E> + ZetaWrite<E>, const PRINT: bool> ZetaWrite
 
     fn write_zeta3(&mut self, n: u64) -> Result<usize, BW::Error> {
         self.bit_write.write_zeta3(n).inspect(|x| {
-            self.bits_written += *x;
+            self.bits_written += *x as u64;
             if PRINT {
                 #[cfg(feature = "std")]
                 eprintln!("write_zeta3({}) = {} (total = {})", n, x, self.bits_written);
@@ -144,7 +146,7 @@ impl<E: Endianness, BW: BitWrite<E> + OmegaWrite<E>, const PRINT: bool> OmegaWri
 {
     fn write_omega(&mut self, n: u64) -> Result<usize, BW::Error> {
         self.bit_write.write_omega(n).inspect(|x| {
-            self.bits_written += *x;
+            self.bits_written += *x as u64;
             if PRINT {
                 #[cfg(feature = "std")]
                 eprintln!("write_omega({}) = {} (total = {})", n, x, self.bits_written);
@@ -158,7 +160,7 @@ impl<E: Endianness, BW: BitWrite<E> + PiWrite<E>, const PRINT: bool> PiWrite<E>
 {
     fn write_pi(&mut self, n: u64, k: usize) -> Result<usize, BW::Error> {
         self.bit_write.write_pi(n, k).inspect(|x| {
-            self.bits_written += *x;
+            self.bits_written += *x as u64;
             if PRINT {
                 #[cfg(feature = "std")]
                 eprintln!(
@@ -171,7 +173,7 @@ impl<E: Endianness, BW: BitWrite<E> + PiWrite<E>, const PRINT: bool> PiWrite<E>
 
     fn write_pi2(&mut self, n: u64) -> Result<usize, BW::Error> {
         self.bit_write.write_pi2(n).inspect(|x| {
-            self.bits_written += *x;
+            self.bits_written += *x as u64;
             if PRINT {
                 #[cfg(feature = "std")]
                 eprintln!("write_pi2({}) = {} (total = {})", n, x, self.bits_written);
@@ -201,8 +203,9 @@ impl<E: Endianness, BW: BitWrite<E> + BitSeek, const PRINT: bool> BitSeek
 #[cfg_attr(feature = "mem_dbg", derive(MemDbg, MemSize))]
 pub struct CountBitReader<E: Endianness, BR: BitRead<E>, const PRINT: bool = false> {
     bit_read: BR,
-    /// The number of bits read (or skipped) so far from the underlying [`BitRead`].
-    pub bits_read: usize,
+    /// The number of bits read (or skipped) so far from the underlying
+    /// [`BitRead`]. Uses u64 (see `bits_written`).
+    pub bits_read: u64,
     _marker: core::marker::PhantomData<E>,
 }
 
@@ -231,7 +234,7 @@ impl<E: Endianness, BR: BitRead<E>, const PRINT: bool> BitRead<E> for CountBitRe
     fn read_bits(&mut self, num_bits: usize) -> Result<u64, Self::Error> {
         self.bit_read.read_bits(num_bits).inspect(|x| {
             let _ = x;
-            self.bits_read += num_bits;
+            self.bits_read += num_bits as u64;
             if PRINT {
                 #[cfg(feature = "std")]
                 eprintln!(
@@ -244,7 +247,7 @@ impl<E: Endianness, BR: BitRead<E>, const PRINT: bool> BitRead<E> for CountBitRe
 
     fn read_unary(&mut self) -> Result<u64, Self::Error> {
         self.bit_read.read_unary().inspect(|x| {
-            self.bits_read += *x as usize + 1;
+            self.bits_read += *x + 1;
             if PRINT {
                 #[cfg(feature = "std")]
                 eprintln!("read_unary() = {} (total = {})", x, self.bits_read);
@@ -257,8 +260,11 @@ impl<E: Endianness, BR: BitRead<E>, const PRINT: bool> BitRead<E> for CountBitRe
     }
 
     fn skip_bits(&mut self, n_bits: usize) -> Result<(), Self::Error> {
+        // Count only on success: a failed skip must not report the bits as
+        // skipped (previously the counter was incremented before the fallible
+        // call).
         self.bit_read.skip_bits(n_bits).inspect(|_| {
-            self.bits_read += n_bits;
+            self.bits_read += n_bits as u64;
             if PRINT {
                 #[cfg(feature = "std")]
                 eprintln!("skip_bits({}) (total = {})", n_bits, self.bits_read);
@@ -267,6 +273,9 @@ impl<E: Endianness, BR: BitRead<E>, const PRINT: bool> BitRead<E> for CountBitRe
     }
 
     fn skip_bits_after_peek(&mut self, n: usize) {
+        // This fast path advances the underlying stream, so count it too;
+        // it is infallible.
+        self.bits_read += n as u64;
         self.bit_read.skip_bits_after_peek(n)
     }
 }
@@ -276,7 +285,7 @@ impl<E: Endianness, BR: BitRead<E> + GammaRead<E>, const PRINT: bool> GammaRead<
 {
     fn read_gamma(&mut self) -> Result<u64, BR::Error> {
         self.bit_read.read_gamma().inspect(|x| {
-            self.bits_read += len_gamma(*x);
+            self.bits_read += len_gamma(*x) as u64;
             if PRINT {
                 #[cfg(feature = "std")]
                 eprintln!("read_gamma() = {} (total = {})", x, self.bits_read);
@@ -290,7 +299,7 @@ impl<E: Endianness, BR: BitRead<E> + DeltaRead<E>, const PRINT: bool> DeltaRead<
 {
     fn read_delta(&mut self) -> Result<u64, BR::Error> {
         self.bit_read.read_delta().inspect(|x| {
-            self.bits_read += len_delta(*x);
+            self.bits_read += len_delta(*x) as u64;
             if PRINT {
                 #[cfg(feature = "std")]
                 eprintln!("read_delta() = {} (total = {})", x, self.bits_read);
@@ -304,7 +313,7 @@ impl<E: Endianness, BR: BitRead<E> + ZetaRead<E>, const PRINT: bool> ZetaRead<E>
 {
     fn read_zeta(&mut self, k: usize) -> Result<u64, BR::Error> {
         self.bit_read.read_zeta(k).inspect(|x| {
-            self.bits_read += len_zeta(*x, k);
+            self.bits_read += len_zeta(*x, k) as u64;
             if PRINT {
                 #[cfg(feature = "std")]
                 eprintln!("read_zeta({}) = {} (total = {})", k, x, self.bits_read);
@@ -314,7 +323,7 @@ impl<E: Endianness, BR: BitRead<E> + ZetaRead<E>, const PRINT: bool> ZetaRead<E>
 
     fn read_zeta3(&mut self) -> Result<u64, BR::Error> {
         self.bit_read.read_zeta3().inspect(|x| {
-            self.bits_read += len_zeta(*x, 3);
+            self.bits_read += len_zeta(*x, 3) as u64;
             if PRINT {
                 #[cfg(feature = "std")]
                 eprintln!("read_zeta3() = {} (total = {})", x, self.bits_read);
@@ -328,7 +337,7 @@ impl<E: Endianness, BR: BitRead<E> + OmegaRead<E>, const PRINT: bool> OmegaRead<
 {
     fn read_omega(&mut self) -> Result<u64, BR::Error> {
         self.bit_read.read_omega().inspect(|x| {
-            self.bits_read += len_omega(*x);
+            self.bits_read += len_omega(*x) as u64;
             if PRINT {
                 #[cfg(feature = "std")]
                 eprintln!("read_omega() = {} (total = {})", x, self.bits_read);
@@ -342,7 +351,7 @@ impl<E: Endianness, BR: BitRead<E> + PiRead<E>, const PRINT: bool> PiRead<E>
 {
     fn read_pi(&mut self, k: usize) -> Result<u64, BR::Error> {
         self.bit_read.read_pi(k).inspect(|x| {
-            self.bits_read += len_pi(*x, k);
+            self.bits_read += len_pi(*x, k) as u64;
             if PRINT {
                 #[cfg(feature = "std")]
                 eprintln!("read_pi({}) = {} (total = {})", k, x, self.bits_read);
@@ -352,7 +361,7 @@ impl<E: Endianness, BR: BitRead<E> + PiRead<E>, const PRINT: bool> PiRead<E>
 
     fn read_pi2(&mut self) -> Result<u64, BR::Error> {
         self.bit_read.read_pi2().inspect(|x| {
-            self.bits_read += len_pi(*x, 2);
+            self.bits_read += len_pi(*x, 2) as u64;
             if PRINT {
                 #[cfg(feature = "std")]
                 eprintln!("read_pi2() = {} (total = {})", x, self.bits_read);
@@ -404,13 +413,16 @@ mod tests {
         count_bit_write.write_zeta3(0)?;
         assert_eq!(count_bit_write.bits_written, 174);
         count_bit_write.write_omega(3)?;
-        assert_eq!(count_bit_write.bits_written, 174 + len_omega(3));
+        assert_eq!(count_bit_write.bits_written, 174 + len_omega(3) as u64);
         let after_omega = count_bit_write.bits_written;
         count_bit_write.write_pi(5, 3)?;
-        assert_eq!(count_bit_write.bits_written, after_omega + len_pi(5, 3));
+        assert_eq!(
+            count_bit_write.bits_written,
+            after_omega + len_pi(5, 3) as u64
+        );
         let after_pi = count_bit_write.bits_written;
         count_bit_write.write_pi2(7)?;
-        assert_eq!(count_bit_write.bits_written, after_pi + len_pi(7, 2));
+        assert_eq!(count_bit_write.bits_written, after_pi + len_pi(7, 2) as u64);
         let after_pi2 = count_bit_write.bits_written;
         count_bit_write.flush()?;
         // Flushing must not change the count
@@ -445,5 +457,28 @@ mod tests {
         assert_eq!(count_bit_read.bits_read, after_pi2);
 
         Ok(())
+    }
+
+    #[test]
+    fn skip_bits_after_peek_is_counted() {
+        let buffer = vec![0u64; 4];
+        let bit_read = <BufBitReader<LE, _>>::new(MemWordReader::<u64, _>::new(&buffer));
+        let mut r = CountBitReader::<_, _, false>::new(bit_read);
+        let _ = r.peek_bits(5).unwrap();
+        r.skip_bits_after_peek(5);
+        // peek does not consume; the post-peek skip advances the stream, so it
+        // must be counted (previously it was not).
+        assert_eq!(r.bits_read, 5);
+    }
+
+    #[test]
+    fn failed_skip_bits_is_not_counted() {
+        // Strict reader over an empty backend: skip_bits hits EOF.
+        let buffer = Vec::<u64>::new();
+        let bit_read = <BufBitReader<LE, _>>::new(MemWordReader::<u64, _>::new(&buffer));
+        let mut r = CountBitReader::<_, _, false>::new(bit_read);
+        assert!(r.skip_bits(1).is_err());
+        // A failed skip must not report the bits as skipped.
+        assert_eq!(r.bits_read, 0);
     }
 }

--- a/src/utils/dbg_codes.rs
+++ b/src/utils/dbg_codes.rs
@@ -10,8 +10,8 @@ use crate::traits::*;
 #[cfg(feature = "mem_dbg")]
 use mem_dbg::{MemDbg, MemSize};
 
-/// A wrapper over a [`BitRead`] that reports on standard error all
-/// operations performed, including all code reads.
+/// A wrapper over a [`BitRead`] that reports on standard error the read
+/// operations it performs (only when the `std` feature is enabled).
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "mem_dbg", derive(MemDbg, MemSize))]
 pub struct DbgBitReader<E: Endianness, R> {
@@ -143,8 +143,8 @@ where
     }
 }
 
-/// A wrapper over a [`BitWrite`] that reports on standard error all operations performed,
-/// including all code writes.
+/// A wrapper over a [`BitWrite`] that reports on standard error the write
+/// operations it performs (only when the `std` feature is enabled).
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "mem_dbg", derive(MemDbg, MemSize))]
 pub struct DbgBitWriter<E: Endianness, W> {

--- a/src/utils/find_change.rs
+++ b/src/utils/find_change.rs
@@ -15,6 +15,11 @@ pub struct FindChangePoints<F: Fn(u64) -> usize> {
     func: F,
     current: u64,
     prev_value: usize,
+    /// Whether the initial `(0, f(0))` point has been emitted. Using a flag
+    /// (rather than a `prev_value == usize::MAX` sentinel) lets `f` legitimately
+    /// return `usize::MAX`, which previously collided with the sentinel and made
+    /// `next` loop forever re-emitting `(0, usize::MAX)`.
+    started: bool,
 }
 
 impl<F: Fn(u64) -> usize> FindChangePoints<F> {
@@ -23,7 +28,8 @@ impl<F: Fn(u64) -> usize> FindChangePoints<F> {
         Self {
             func,
             current: 0,
-            prev_value: usize::MAX,
+            prev_value: 0,
+            started: false,
         }
     }
 }
@@ -34,7 +40,8 @@ impl<F: Fn(u64) -> usize> Iterator for FindChangePoints<F> {
 
     fn next(&mut self) -> Option<Self::Item> {
         // handle the first case, we don't need to search for the first change
-        if self.current == 0 && self.prev_value == usize::MAX {
+        if !self.started {
+            self.started = true;
             self.prev_value = (self.func)(0);
             return Some((0, self.prev_value));
         }
@@ -114,6 +121,15 @@ mod tests {
         test_func(crate::codes::len_omega);
         test_func(|x| crate::codes::len_zeta(x, 3));
         test_func(|x| crate::codes::len_pi(x, 3));
+    }
+
+    #[test]
+    fn constant_usize_max_terminates() {
+        // A length function that returns usize::MAX everywhere used to collide
+        // with the initialization sentinel and re-emit (0, usize::MAX) forever.
+        let mut it = FindChangePoints::new(|_| usize::MAX);
+        assert_eq!(it.next(), Some((0, usize::MAX)));
+        assert_eq!(it.next(), None);
     }
 
     fn test_func(func: impl Fn(u64) -> usize) {

--- a/src/utils/implied.rs
+++ b/src/utils/implied.rs
@@ -16,21 +16,35 @@ use rand::prelude::*;
 /// probability 2⁻*ⁿ*.
 ///
 /// This function works only with monotonic non-decreasing length functions. It
-/// returns two vectors: the first vector contains one entry per distinct code
-/// length up to 128, plus one sentinel entry (the first change point with
-/// length > 128) that serves as the upper bound for the last valid group; the
-/// second vector contains the probability of each valid length group; its
-/// length is always one less than that of the first vector.
+/// returns two vectors: the first contains one entry per distinct code length,
+/// followed by a sentinel entry that upper-bounds the last group -- either the
+/// first change point with length > 128, or, if the function never exceeds 128,
+/// the end of the domain (`u64::MAX`, exclusive). The second vector contains the
+/// probability of each length group; its length is always one less than that of
+/// the first.
 pub fn get_implied_distribution(f: impl Fn(u64) -> usize) -> (Vec<(u64, usize)>, Vec<f64>) {
     // Collect change points with code length up to 128, plus the first
     // change point with length > 128 as a sentinel upper bound for the
     // last valid length group.
     let mut change_points = Vec::new();
+    let mut hit_sentinel = false;
     for item in FindChangePoints::new(f) {
         let len = item.1;
         change_points.push(item);
         if len > 128 {
+            hit_sentinel = true;
             break;
+        }
+    }
+    // Real code length functions stay well below 128, so FindChangePoints
+    // exhausts without ever emitting the > 128 sentinel. Append an upper bound
+    // at the end of the domain (u64::MAX, exclusive) so the windows(2) below
+    // does not drop the final (highest-value) length group.
+    if !hit_sentinel {
+        if let Some(&(last_input, last_len)) = change_points.last() {
+            if last_input != u64::MAX {
+                change_points.push((u64::MAX, last_len));
+            }
         }
     }
 
@@ -122,13 +136,25 @@ mod tests {
     use rand::rngs::SmallRng;
 
     #[test]
-    fn constant_length_samples_uniformly_without_panic() {
+    fn constant_length_samples_without_panic() {
         let mut rng = SmallRng::seed_from_u64(0);
-        // A constant length function has an empty set of probability groups; it
-        // must sample uniformly instead of panicking on WeightedIndex::new.
+        // A constant length function yields a single length group spanning the
+        // whole domain; sampling must not panic.
         let vals: Vec<u64> = sample_implied_distribution(|_| 7, &mut rng)
             .take(100)
             .collect();
         assert_eq!(vals.len(), 100);
+    }
+
+    #[test]
+    fn distribution_includes_final_group() {
+        use super::get_implied_distribution;
+        use crate::codes::len_gamma;
+        let (change_points, probabilities) = get_implied_distribution(len_gamma);
+        // Real code lengths never exceed 128, so the last group used to be
+        // dropped; it must now be present, bounded by the domain-end sentinel.
+        assert!(!probabilities.is_empty());
+        assert_eq!(probabilities.len(), change_points.len() - 1);
+        assert_eq!(change_points.last().unwrap().0, u64::MAX);
     }
 }

--- a/src/utils/implied.rs
+++ b/src/utils/implied.rs
@@ -90,15 +90,45 @@ pub fn sample_implied_distribution(
     rng: &mut impl Rng,
 ) -> impl Iterator<Item = u64> + '_ {
     let (change_points, probabilities) = get_implied_distribution(len);
-    let dist = WeightedIndex::new(probabilities)
-        .expect("get_implied_distribution returns non-empty, positive weights");
+    // A length function that is constant over the whole u64 domain yields a
+    // single change point and no probability groups; its implied distribution
+    // is then uniform (every value has the same codeword length). Handle that
+    // case without panicking, and use the weighted distribution otherwise.
+    let dist = if probabilities.is_empty() {
+        None
+    } else {
+        Some(
+            WeightedIndex::new(probabilities)
+                .expect("get_implied_distribution returns positive weights"),
+        )
+    };
 
-    InfiniteIterator.map(move |_| {
-        // sample a len with the correct probability
-        let idx = dist.sample(rng);
-        // now we sample a random value with the sampled len
-        let (start_input, _len) = change_points[idx];
-        let (end_input, _len) = change_points[idx + 1];
-        rng.random_range(start_input..end_input)
+    InfiniteIterator.map(move |_| match &dist {
+        None => rng.random::<u64>(),
+        Some(dist) => {
+            // sample a length with the correct probability, then a value with it
+            let idx = dist.sample(rng);
+            let (start_input, _len) = change_points[idx];
+            let (end_input, _len) = change_points[idx + 1];
+            rng.random_range(start_input..end_input)
+        }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sample_implied_distribution;
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+
+    #[test]
+    fn constant_length_samples_uniformly_without_panic() {
+        let mut rng = SmallRng::seed_from_u64(0);
+        // A constant length function has an empty set of probability groups; it
+        // must sample uniformly instead of panicking on WeightedIndex::new.
+        let vals: Vec<u64> = sample_implied_distribution(|_| 7, &mut rng)
+            .take(100)
+            .collect();
+        assert_eq!(vals.len(), 100);
+    }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -12,9 +12,9 @@
 //! and [`BitWrite`](crate::traits::BitWrite), respectively,
 //! optionally printing on standard error the operations performed on the stream.
 //!
-//! [`DbgBitReader`] and [`DbgBitWriter`] print on standard error all
-//! operations performed by a [`BitRead`](crate::traits::BitRead) or
-//! [`BitWrite`](crate::traits::BitWrite).
+//! [`DbgBitReader`] and [`DbgBitWriter`] print the operations performed by a
+//! [`BitRead`](crate::traits::BitRead) or [`BitWrite`](crate::traits::BitWrite)
+//! on standard error (only when the `std` feature is enabled).
 //!
 //! [`CodesStats`] keeps track of the space needed to store a stream of
 //! integers using different codes.

--- a/src/utils/stats.rs
+++ b/src/utils/stats.rs
@@ -10,8 +10,8 @@
 use mem_dbg::{MemDbg, MemSize};
 
 use crate::prelude::{
-    Codes, bit_len_vbyte, len_delta, len_exp_golomb, len_gamma, len_golomb, len_omega, len_pi,
-    len_rice, len_zeta,
+    Codes, bit_len_vbyte, len_delta, len_exp_golomb, len_gamma, len_minimal_binary, len_omega,
+    len_pi, len_zeta,
 };
 use core::fmt::Debug;
 
@@ -134,54 +134,120 @@ impl<
     /// Update the stats with `count` occurrences of `n` and return `n` for convenience.
     #[inline]
     pub fn update_many(&mut self, n: u64, count: u64) -> u64 {
-        self.total += count;
-        self.unary += (n + 1) * count;
-        self.gamma += len_gamma(n) as u64 * count;
-        self.delta += len_delta(n) as u64 * count;
-        self.omega += len_omega(n) as u64 * count;
-        self.vbyte += bit_len_vbyte(n) as u64 * count;
+        // No occurrences: record nothing (and skip the u64::MAX branch, which
+        // would otherwise poison totals for a value never actually seen).
+        if count == 0 {
+            return n;
+        }
+        self.total = self.total.saturating_add(count);
 
+        // u64::MAX is outside the [0, 2^64 - 1) range of the instantaneous
+        // codes; their length helpers compute n + 1 and would panic (ilog2(0)).
+        // Saturate only the codes that cannot represent it -- unary, gamma,
+        // delta, omega, every zeta/pi, Golomb with b = 1, Rice with k = 0 and
+        // exp-Golomb with k = 0 (length 2^64 or undefined) -- and compute the
+        // finite candidates (VByte, and Golomb/Rice/exp-Golomb with a larger
+        // parameter) so best_code can still pick a representable code.
+        if n == u64::MAX {
+            self.unary = u64::MAX;
+            self.gamma = u64::MAX;
+            self.delta = u64::MAX;
+            self.omega = u64::MAX;
+            self.vbyte = self
+                .vbyte
+                .saturating_add((bit_len_vbyte(n) as u64).saturating_mul(count));
+            self.zeta.iter_mut().for_each(|v| *v = u64::MAX);
+            self.pi.iter_mut().for_each(|v| *v = u64::MAX);
+            for (b, val) in self.golomb.iter_mut().enumerate() {
+                let b = (b + 1) as u64;
+                *val = if b == 1 {
+                    u64::MAX
+                } else {
+                    let len = (n / b) + 1 + len_minimal_binary(n % b, b) as u64;
+                    val.saturating_add(len.saturating_mul(count))
+                };
+            }
+            for (k, val) in self.exp_golomb.iter_mut().enumerate() {
+                *val = if k == 0 {
+                    u64::MAX
+                } else {
+                    val.saturating_add((len_exp_golomb(n, k) as u64).saturating_mul(count))
+                };
+            }
+            for (log2_b, val) in self.rice.iter_mut().enumerate() {
+                *val = if log2_b == 0 {
+                    u64::MAX
+                } else {
+                    let len = (n >> log2_b) + 1 + log2_b as u64;
+                    val.saturating_add(len.saturating_mul(count))
+                };
+            }
+            return n;
+        }
+
+        // Saturating arithmetic: an overflowing total means the code is
+        // impractically large for this data, so it saturates (and never wins
+        // best_code) instead of panicking (debug) or wrapping to a small,
+        // wrongly-winning value (release). n < u64::MAX here, so n + 1 is exact.
+        self.unary = self.unary.saturating_add((n + 1).saturating_mul(count));
+        self.gamma = self
+            .gamma
+            .saturating_add((len_gamma(n) as u64).saturating_mul(count));
+        self.delta = self
+            .delta
+            .saturating_add((len_delta(n) as u64).saturating_mul(count));
+        self.omega = self
+            .omega
+            .saturating_add((len_omega(n) as u64).saturating_mul(count));
+        self.vbyte = self
+            .vbyte
+            .saturating_add((bit_len_vbyte(n) as u64).saturating_mul(count));
         for (k, val) in self.zeta.iter_mut().enumerate() {
-            *val += (len_zeta(n, (k + 1) as _) as u64) * count;
+            *val = val.saturating_add((len_zeta(n, (k + 1) as _) as u64).saturating_mul(count));
         }
         for (b, val) in self.golomb.iter_mut().enumerate() {
-            *val += (len_golomb(n, (b + 1) as _) as u64) * count;
+            // Length in u64 to avoid truncating n / b on 32-bit targets, where
+            // len_golomb's usize return can drop high bits.
+            let b = (b + 1) as u64;
+            let len = (n / b) + 1 + len_minimal_binary(n % b, b) as u64;
+            *val = val.saturating_add(len.saturating_mul(count));
         }
         for (k, val) in self.exp_golomb.iter_mut().enumerate() {
-            *val += (len_exp_golomb(n, k as _) as u64) * count;
+            *val = val.saturating_add((len_exp_golomb(n, k as _) as u64).saturating_mul(count));
         }
         for (log2_b, val) in self.rice.iter_mut().enumerate() {
-            *val += (len_rice(n, log2_b as _) as u64) * count;
+            // Length in u64 to avoid truncating n >> log2_b on 32-bit targets.
+            let len = (n >> log2_b) + 1 + log2_b as u64;
+            *val = val.saturating_add(len.saturating_mul(count));
         }
-        // π₀ = γ and π₁ = ζ₂ in terms of codeword lengths
         for (k, val) in self.pi.iter_mut().enumerate() {
-            *val += (len_pi(n, (k + 2) as _) as u64) * count;
+            *val = val.saturating_add((len_pi(n, (k + 2) as _) as u64).saturating_mul(count));
         }
         n
     }
 
     /// Combines additively this stats with another one.
     pub fn add(&mut self, rhs: &Self) {
-        self.total += rhs.total;
-        self.unary += rhs.unary;
-        self.gamma += rhs.gamma;
-        self.delta += rhs.delta;
-        self.omega += rhs.omega;
-        self.vbyte += rhs.vbyte;
+        self.total = self.total.saturating_add(rhs.total);
+        self.unary = self.unary.saturating_add(rhs.unary);
+        self.gamma = self.gamma.saturating_add(rhs.gamma);
+        self.delta = self.delta.saturating_add(rhs.delta);
+        self.omega = self.omega.saturating_add(rhs.omega);
+        self.vbyte = self.vbyte.saturating_add(rhs.vbyte);
         for (a, b) in self.zeta.iter_mut().zip(rhs.zeta.iter()) {
-            *a += *b;
+            *a = a.saturating_add(*b);
         }
         for (a, b) in self.golomb.iter_mut().zip(rhs.golomb.iter()) {
-            *a += *b;
+            *a = a.saturating_add(*b);
         }
         for (a, b) in self.exp_golomb.iter_mut().zip(rhs.exp_golomb.iter()) {
-            *a += *b;
+            *a = a.saturating_add(*b);
         }
         for (a, b) in self.rice.iter_mut().zip(rhs.rice.iter()) {
-            *a += *b;
+            *a = a.saturating_add(*b);
         }
         for (a, b) in self.pi.iter_mut().zip(rhs.pi.iter()) {
-            *a += *b;
+            *a = a.saturating_add(*b);
         }
     }
 
@@ -651,5 +717,43 @@ mod serde_tests {
         let json = serde_json::to_string_pretty(&stats).unwrap();
         // This should panic because the JSON has 20 golomb values but we expect 21
         let _deserialized: CodesStats<10, 21, 5, 8, 6> = serde_json::from_str(&json).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod robustness_tests {
+    use super::*;
+
+    #[test]
+    fn u64_max_does_not_panic_and_picks_finite_code() {
+        let mut stats: CodesStats = CodesStats::default();
+        // Previously len_gamma(u64::MAX) panicked via ilog2(0); this must not
+        // panic and must still pick a code that can represent u64::MAX.
+        stats.update(u64::MAX);
+        let (code, bits) = stats.best_code();
+        assert_eq!(code, Codes::VByteBe);
+        assert_eq!(bits, 80);
+    }
+
+    #[test]
+    fn count_zero_is_a_noop() {
+        let mut stats: CodesStats = CodesStats::default();
+        let before = stats;
+        stats.update_many(u64::MAX, 0);
+        assert_eq!(
+            stats, before,
+            "update_many with count 0 must change nothing"
+        );
+    }
+
+    #[test]
+    fn large_count_saturates_without_panic() {
+        let mut stats: CodesStats = CodesStats::default();
+        // (n + 1) * count overflows u64; it must saturate rather than panic
+        // (debug) or wrap to a small, wrongly-winning value (release).
+        stats.update_many(1 << 40, 1 << 30);
+        let (_, bits) = stats.best_code();
+        // A finite-length code (e.g. gamma) still wins; unary saturated.
+        assert!(bits < u64::MAX);
     }
 }

--- a/tests/test_copy.rs
+++ b/tests/test_copy.rs
@@ -170,3 +170,70 @@ where
 
     Ok(())
 }
+
+/// 16 varied words; word 0 has both its MSB and LSB set so that a leading
+/// 1-bit read is nonzero for either endianness.
+fn topup_sample_words() -> [u64; 16] {
+    [
+        0x8000_0000_0000_0001,
+        0xfedc_ba98_7654_3210,
+        0x0123_4567_89ab_cdef,
+        0xdead_beef_cafe_babe,
+        0x1111_2222_3333_4444,
+        0x5555_6666_7777_8888,
+        0x9999_aaaa_bbbb_cccc,
+        0xdddd_eeee_ffff_0000,
+        0x0f0f_0f0f_0f0f_0f0f,
+        0xf0f0_f0f0_f0f0_f0f0,
+        0xaaaa_5555_aaaa_5555,
+        0x1234_1234_1234_1234,
+        0xabcd_ef01_2345_6789,
+        0x9e37_79b9_7f4a_7c15,
+        0x6a09_e667_f3bc_c908,
+        0xbb67_ae85_84ca_a73b,
+    ]
+}
+
+fn read_bit_seq<E: Endianness>(r: &mut impl BitRead<E>, n: usize) -> Vec<u64> {
+    (0..n).map(|_| r.read_bits(1).unwrap()).collect()
+}
+
+/// After a 1-bit read, the two-word refill top-up leaves `2 * WORD_BITS - 1`
+/// bits in the bit buffer (more than one word), so a bulk `copy_to` must
+/// drain more than `WORD_BITS` buffered bits without exceeding the 64-bit
+/// `write_bits` contract.
+fn copy_to_after_topup<E: Endianness, W: Word + PrimitiveInteger + DoubleType + 'static>(
+    words: &[W],
+) where
+    BufBitReader<E, MemWordReader<W, Vec<W>, true>>: BitRead<E>,
+    BufBitReader<E, MemWordReader<u64, Vec<u64>, true>>: BitRead<E>,
+    BufBitWriter<E, MemWordWriterVec<u64, Vec<u64>>>: BitWrite<E>,
+{
+    const N: usize = 200;
+    let mut refr = BufBitReader::<E, _>::new(MemWordReader::new_inf(words.to_vec()));
+    let _ = refr.read_bits(1).unwrap();
+    let expected = read_bit_seq::<E>(&mut refr, N);
+
+    let mut src = BufBitReader::<E, _>::new(MemWordReader::new_inf(words.to_vec()));
+    let _ = src.read_bits(1).unwrap();
+    let mut wr = BufBitWriter::<E, _>::new(MemWordWriterVec::new(Vec::<u64>::new()));
+    // Lossless: N is a small constant and usize is at most 64 bits wide.
+    src.copy_to(&mut wr, N as u64).unwrap();
+    let out = wr.into_inner().unwrap().into_inner();
+    let mut back = BufBitReader::<E, _>::new(MemWordReader::new_inf(out));
+    assert_eq!(read_bit_seq::<E>(&mut back, N), expected);
+}
+
+#[test]
+fn test_copy_to_after_topup() {
+    let w64 = topup_sample_words();
+    copy_to_after_topup::<BE, u64>(&w64);
+    copy_to_after_topup::<LE, u64>(&w64);
+    let w32: Vec<u32> = w64
+        .iter()
+        // Intended truncation: split each u64 into its two u32 halves.
+        .flat_map(|w| [(*w >> 32) as u32, *w as u32])
+        .collect();
+    copy_to_after_topup::<BE, u32>(&w32);
+    copy_to_after_topup::<LE, u32>(&w32);
+}

--- a/tests/test_dispatch.rs
+++ b/tests/test_dispatch.rs
@@ -1,0 +1,152 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+//! Behavioral coverage for the hand-maintained code-dispatch matrices: the
+//! dynamic `Codes` dispatch (dispatch::codes), the function-pointer tables
+//! (dispatch::dynamic: FuncCodeReader/Writer/Len) and the const dispatch
+//! (dispatch::static: ConstCode).
+//!
+//! The dynamic and function-pointer matrices are cross-validated against each
+//! other: for each code the two are encoded into *separate* buffers, the
+//! codewords and lengths must be byte-for-byte identical, and each buffer is
+//! read back through the *other* matrix. A wrong arm in either matrix that
+//! diverges from the other is therefore caught (a byte mismatch or a wrong
+//! decoded value), not hidden by reading each buffer with its own matching arm.
+#![cfg(feature = "alloc")]
+
+use dsi_bitstream::dispatch::{
+    CodeLen, Codes, ConstCode, DynamicCodeRead, DynamicCodeWrite, FuncCodeLen, FuncCodeReader,
+    FuncCodeWriter, StaticCodeRead, StaticCodeWrite, code_consts,
+};
+use dsi_bitstream::prelude::*;
+
+// A representative code from every family, including several parameter values
+// for the parameterized codes and both VByte byte orders.
+const CODES: &[Codes] = &[
+    Codes::Unary,
+    Codes::Gamma,
+    Codes::Delta,
+    Codes::Omega,
+    Codes::VByteLe,
+    Codes::VByteBe,
+    Codes::Zeta(1),
+    Codes::Zeta(2),
+    Codes::Zeta(3),
+    Codes::Zeta(6),
+    Codes::Pi(0),
+    Codes::Pi(1),
+    Codes::Pi(3),
+    Codes::Golomb(1),
+    Codes::Golomb(3),
+    Codes::Golomb(7),
+    Codes::ExpGolomb(0),
+    Codes::ExpGolomb(2),
+    Codes::ExpGolomb(5),
+    Codes::Rice(0),
+    Codes::Rice(3),
+    Codes::Rice(7),
+];
+const VALUES: &[u64] = &[0, 1, 2, 7, 100, 1000, 100_000];
+
+fn encode<E, F>(f: F) -> (usize, Vec<u64>)
+where
+    E: Endianness,
+    BufBitWriter<E, MemWordWriterVec<u64, Vec<u64>>>: BitWrite<E> + CodesWrite<E>,
+    F: FnOnce(&mut BufBitWriter<E, MemWordWriterVec<u64, Vec<u64>>>) -> usize,
+{
+    let mut w = BufBitWriter::<E, _>::new(MemWordWriterVec::new(Vec::<u64>::new()));
+    let bits = f(&mut w);
+    (bits, w.into_inner().unwrap().into_inner())
+}
+
+fn check_matrix<E: Endianness>()
+where
+    BufBitWriter<E, MemWordWriterVec<u64, Vec<u64>>>: BitWrite<E> + CodesWrite<E>,
+    BufBitReader<E, MemWordReader<u64, Vec<u64>, true>>: BitRead<E> + CodesRead<E>,
+{
+    for &code in CODES {
+        let fr = FuncCodeReader::<E, _>::new(code).unwrap();
+        let fw = FuncCodeWriter::<E, _>::new(code).unwrap();
+        let fl = FuncCodeLen::new(code).unwrap();
+        for &n in VALUES {
+            let (bits_dyn, buf_dyn) =
+                encode::<E, _>(|w| DynamicCodeWrite::write(&code, w, n).unwrap());
+            let (bits_fw, buf_fw) = encode::<E, _>(|w| StaticCodeWrite::write(&fw, w, n).unwrap());
+
+            // The two writer matrices must emit identical codewords and lengths.
+            assert_eq!(
+                bits_dyn, bits_fw,
+                "writer length mismatch for {code:?} n={n}"
+            );
+            assert_eq!(
+                buf_dyn, buf_fw,
+                "writer codeword mismatch for {code:?} n={n}"
+            );
+            assert_eq!(
+                bits_dyn,
+                code.len(n),
+                "Codes::len mismatch for {code:?} n={n}"
+            );
+            assert_eq!(
+                bits_dyn,
+                fl.get_func()(n),
+                "FuncCodeLen mismatch for {code:?} n={n}"
+            );
+
+            // Cross-read: read each buffer with the *other* matrix's reader.
+            let mut r_dyn = BufBitReader::<E, _>::new(MemWordReader::new_inf(buf_dyn));
+            assert_eq!(
+                StaticCodeRead::read(&fr, &mut r_dyn).unwrap(),
+                n,
+                "FuncCodeReader on dynamic-encoded buffer for {code:?} n={n}"
+            );
+            let mut r_fw = BufBitReader::<E, _>::new(MemWordReader::new_inf(buf_fw));
+            assert_eq!(
+                DynamicCodeRead::read(&code, &mut r_fw).unwrap(),
+                n,
+                "Codes::read on func-encoded buffer for {code:?} n={n}"
+            );
+        }
+    }
+}
+
+#[test]
+fn dispatch_matrix_be() {
+    check_matrix::<BE>();
+}
+
+#[test]
+fn dispatch_matrix_le() {
+    check_matrix::<LE>();
+}
+
+#[test]
+fn const_code_roundtrips() {
+    const N: u64 = 100;
+    // One representative const per family; ConstCode delegates through the
+    // static-dispatch matrices, so a wrong const->code mapping is caught here.
+    macro_rules! rt {
+        ($c:expr) => {{
+            let code = ConstCode::<{ $c }>;
+            let mut w = BufBitWriter::<BE, _>::new(MemWordWriterVec::new(Vec::<u64>::new()));
+            let bits = StaticCodeWrite::write(&code, &mut w, N).unwrap();
+            let buf = w.into_inner().unwrap().into_inner();
+            assert_eq!(bits, code.len(N), "ConstCode len mismatch for const {}", $c);
+            let mut r = BufBitReader::<BE, _>::new(MemWordReader::new_inf(buf));
+            assert_eq!(
+                StaticCodeRead::read(&code, &mut r).unwrap(),
+                N,
+                "ConstCode roundtrip mismatch for const {}",
+                $c
+            );
+        }};
+    }
+    rt!(code_consts::UNARY);
+    rt!(code_consts::GAMMA);
+    rt!(code_consts::DELTA);
+    rt!(code_consts::OMEGA);
+    rt!(code_consts::VBYTE_BE);
+    rt!(code_consts::VBYTE_LE);
+    rt!(code_consts::ZETA3);
+}

--- a/tests/test_from.rs
+++ b/tests/test_from.rs
@@ -5,7 +5,7 @@
  */
 #![cfg(feature = "std")]
 
-use std::{env, path::PathBuf};
+use std::env;
 
 use dsi_bitstream::{
     codes::{DeltaRead, DeltaWrite},
@@ -15,15 +15,22 @@ use dsi_bitstream::{
 
 #[test]
 fn test_from() -> Result<(), Box<dyn core::error::Error>> {
-    let temp_dir: PathBuf = env::temp_dir();
-    let mut writer = buf_bit_writer::from_path::<LE, u64>(&temp_dir.join("test.bin"))?;
+    // Unique per-process path so concurrent test binaries do not clobber one
+    // another (and to avoid reusing a predictable, possibly pre-existing file).
+    let path = env::temp_dir().join(format!(
+        "dsi_bitstream_test_from_{}.bin",
+        std::process::id()
+    ));
+    let mut writer = buf_bit_writer::from_path::<LE, u64>(&path)?;
     for i in 0..100 {
         writer.write_delta(i)?;
     }
     drop(writer);
-    let mut reader = buf_bit_reader::from_path::<LE, u64>(&temp_dir.join("test.bin"))?;
+    let mut reader = buf_bit_reader::from_path::<LE, u64>(&path)?;
     for i in 0..100 {
         assert_eq!(reader.read_delta()?, i);
     }
+    drop(reader);
+    let _ = std::fs::remove_file(&path);
     Ok(())
 }

--- a/tests/test_io_partial.rs
+++ b/tests/test_io_partial.rs
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+//! std::io::{Read,Write} adapters must report the bytes actually transferred,
+//! must not lose readable bytes on a narrow-word backend near EOF, and must
+//! leave the writer in a clean state on a backend error so a write_all retry is
+//! safe and produces exactly the same output as an uninterrupted write.
+#![cfg(feature = "std")]
+
+use dsi_bitstream::prelude::*;
+use dsi_bitstream::traits::{BE, Endianness, LE, WordError, WordWrite};
+
+/// A `WordWrite` (u8 words) that fails on the `fail_at`-th `write_word` call and
+/// records every word it accepts.
+struct FailOnce {
+    fail_at: usize,
+    calls: usize,
+    words: Vec<u8>,
+}
+impl FailOnce {
+    fn new(fail_at: usize) -> Self {
+        Self {
+            fail_at,
+            calls: 0,
+            words: Vec::new(),
+        }
+    }
+}
+impl WordWrite for FailOnce {
+    type Error = WordError;
+    type Word = u8;
+    fn write_word(&mut self, word: u8) -> Result<(), Self::Error> {
+        let c = self.calls;
+        self.calls += 1;
+        if c == self.fail_at {
+            return Err(WordError::UnexpectedEof { word_pos: c });
+        }
+        self.words.push(word);
+        Ok(())
+    }
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+#[test]
+fn read_returns_partial_without_losing_bytes_be() {
+    // Strict u8-word backend with only 3 bytes; a chunked read_bits(64) would
+    // consume all three words, error, and copy zero bytes (data loss). The
+    // byte-by-byte adapter returns all 3.
+    let data: [u8; 3] = [0xAA, 0xBB, 0xCC];
+    let mut r = BufBitReader::<BE, _>::new(MemWordReader::new(&data));
+    let mut buf = [0u8; 8];
+    let n = std::io::Read::read(&mut r, &mut buf).unwrap();
+    assert_eq!(n, 3);
+    assert_eq!(&buf[..3], &[0xAA, 0xBB, 0xCC]);
+}
+
+#[test]
+fn read_returns_partial_without_losing_bytes_le() {
+    let data: [u8; 3] = [0xAA, 0xBB, 0xCC];
+    let mut r = BufBitReader::<LE, _>::new(MemWordReader::new(&data));
+    let mut buf = [0u8; 8];
+    let n = std::io::Read::read(&mut r, &mut buf).unwrap();
+    assert_eq!(n, 3);
+    assert_eq!(&buf[..3], &[0xAA, 0xBB, 0xCC]);
+}
+
+#[test]
+fn write_errors_when_no_bytes_accepted_and_stays_clean() {
+    // u8 words: the first byte fills a word and flushes, which fails; no byte
+    // was accepted, so write returns Err. Because the adapter restores the
+    // buffer state, flushing the writer afterwards does not panic.
+    let mut w = BufBitWriter::<BE, _>::new(FailOnce::new(0));
+    assert!(std::io::Write::write(&mut w, &[1, 2, 3]).is_err());
+    let backend = w.into_inner().unwrap();
+    assert!(backend.words.is_empty());
+}
+
+fn recover<E: Endianness>()
+where
+    BufBitWriter<E, FailOnce>: BitWrite<E> + std::io::Write,
+{
+    let data = [0x11u8, 0x22, 0x33, 0x44, 0x55];
+
+    // Reference: the same 4-bit prefix + bytes written to a backend that never
+    // fails, giving the correct sequence of accepted words.
+    let mut w_ref = BufBitWriter::<E, _>::new(FailOnce::new(usize::MAX));
+    w_ref.write_bits(0b1010, 4).unwrap();
+    std::io::Write::write_all(&mut w_ref, &data).unwrap();
+    let expected = w_ref.into_inner().unwrap().words;
+
+    // Fail-once: a write_all-style retry loop must reproduce exactly the same
+    // words (no loss, no duplication) because the adapter restores the writer on
+    // the transient error.
+    let mut w = BufBitWriter::<E, _>::new(FailOnce::new(1));
+    w.write_bits(0b1010, 4).unwrap();
+    let mut pos = 0;
+    let mut attempts = 0;
+    while pos < data.len() {
+        attempts += 1;
+        assert!(attempts < 1000, "no forward progress");
+        match std::io::Write::write(&mut w, &data[pos..]) {
+            Ok(0) => panic!("write returned 0"),
+            Ok(n) => pos += n,
+            Err(_) => {} // transient; writer restored, retry from pos
+        }
+    }
+    let got = w.into_inner().unwrap().words;
+    assert_eq!(
+        got, expected,
+        "fail-once recovery must match an uninterrupted write"
+    );
+}
+
+#[test]
+fn write_recovers_after_transient_backend_error_be() {
+    recover::<BE>();
+}
+
+#[test]
+fn write_recovers_after_transient_backend_error_le() {
+    recover::<LE>();
+}
+
+#[test]
+fn read_after_exhaustion_errors_instead_of_silent_eof() {
+    // The adapter cannot distinguish clean EOF from a backend failure, so
+    // reading past the end must fail loudly with UnexpectedEof, never
+    // return Ok(0): a genuine backend error must not look like a clean EOF.
+    let data: [u8; 3] = [0xAA, 0xBB, 0xCC];
+    let mut r = BufBitReader::<BE, _>::new(MemWordReader::new(&data));
+    let mut buf = [0u8; 8];
+    assert_eq!(std::io::Read::read(&mut r, &mut buf).unwrap(), 3);
+    let err = std::io::Read::read(&mut r, &mut buf).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+
+    let mut r = BufBitReader::<LE, _>::new(MemWordReader::new(&data));
+    let mut buf = [0u8; 8];
+    assert_eq!(std::io::Read::read(&mut r, &mut buf).unwrap(), 3);
+    let err = std::io::Read::read(&mut r, &mut buf).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+
+    // Ok(0) still means "empty buffer", as the Read contract requires, even
+    // on an exhausted stream.
+    let mut r = BufBitReader::<BE, _>::new(MemWordReader::new(&data));
+    assert_eq!(std::io::Read::read(&mut r, &mut []).unwrap(), 0);
+    let mut buf = [0u8; 8];
+    assert_eq!(std::io::Read::read(&mut r, &mut buf).unwrap(), 3);
+    assert_eq!(std::io::Read::read(&mut r, &mut []).unwrap(), 0);
+}
+
+#[test]
+fn read_exact_and_bounded_read_to_end_work_on_finite_input() {
+    let data: [u8; 3] = [0xAA, 0xBB, 0xCC];
+    // read_exact of the exact length succeeds...
+    let mut r = BufBitReader::<LE, _>::new(MemWordReader::new(&data));
+    let mut buf = [0u8; 3];
+    std::io::Read::read_exact(&mut r, &mut buf).unwrap();
+    assert_eq!(&buf, &data);
+    // ...and read_to_end works through a bounded `take`, the documented way
+    // to read a known-length stream to its end.
+    let r = BufBitReader::<BE, _>::new(MemWordReader::new(&data));
+    let mut out = Vec::new();
+    std::io::Read::read_to_end(&mut std::io::Read::take(r, 3), &mut out).unwrap();
+    assert_eq!(out, data);
+}

--- a/tests/test_word_pos.rs
+++ b/tests/test_word_pos.rs
@@ -33,9 +33,9 @@ fn test_word_pos() -> Result<(), Box<dyn core::error::Error>> {
     let mut reader = CountBitReader::<_, _, false>::new(reader);
     for _ in 0..100 {
         let _ = reader.read_gamma()?;
+        let pos = reader.bit_pos()?;
         assert_eq!(
-            reader.bits_read as u64,
-            reader.bit_pos()?,
+            reader.bits_read, pos,
             "Number of bits read and position in bit stream are different"
         );
     }


### PR DESCRIPTION
## Overview

Rebase of the original branch onto the new `main` (`72c65bc`, "Limit peekable bits to half the buffer instead of peeking twice"). This was not a mechanical rebase: `main` independently reworked the same buffering area and absorbed several of this PR's fixes, so each side was re-evaluated -- correctness first, then performance -- and the stack was rebuilt commit by commit (22 commits: 1 perf, 1 new contract fix, 20 remediation).

## Buffering: evaluated both designs, shipped a hybrid

- `main` (`72c65bc`): `PEEK_BITS` = one word, so a peek needs at most one refill and the bit buffer is never completely full -- no full-buffer handling anywhere; original single-refill hot paths.
- The previous branch: `PEEK_BITS` = word + 1 with full-buffer guards on every hot path, plus the optimization campaign's straight-line refill arm and two-word top-up.

The two are orthogonal: the top-up leaves at most `BUFFER_BITS - 1` bits, so it *preserves* `main`'s never-full invariant and introduces no buffer state a `peek_bits` refill cannot already produce. The rebased `perf(reader)` commit therefore keeps `main`'s invariant, `PEEK_BITS`, and hot-path structure, and adds only the campaign's refill arms: a straight-line single-word arm for word-crossing requests of at most `WORD_BITS` bits, a u64-arithmetic helper for 64-bit words (avoids cross-half u128 shifts), and a two-word top-up on peekable backends. All full-buffer guards are gone. The pass-12 merged unary shift is kept only for 128-bit buffers (its stable -13% case); 64-bit buffers keep `main`'s two-step shift, which an isolated A/B on a non-peekable backend showed to be the faster form there.

### New `WordRead` API: one atomic method

The top-up word is obtained through a new defaulted trait method, `WordRead::read_word_opt(&mut self) -> Option<Word>`: it atomically reads *and consumes* the next word if the backend can determine cheaply that one is available, never fails, and never consumes past the end. A peek-then-skip pair was considered and rejected: the trait would have allowed a conforming third-party backend to fail the skip after the reader had already consumed its first word, corrupting reader state; with a single infallible consume-if-available call that hazard is unrepresentable. `MemWordReader` overrides it; every other backend inherits the `None` default and is unaffected (the top-up folds away at monomorphization).

`test_topup_at_end_of_stream` pins the boundary behavior on a strict finite backend for both endiannesses: 96 bits are read back in top-up-crossing widths with full value decomposition checked against independent 64+32-bit reads, the reader works through the exact end of the data, and only then errors -- no word is consumed early, lost, or duplicated.

### Measurements

7950X3D pinned to a V-cache core (`autoresearch.sh` reproduces the focused measurement; per-revision attribution in the `perf(reader)` commit message):

- Focused 10-case harness, three-way: geomean `main` 1.721 ns/op, previous branch 1.440, hybrid 1.358 (per-case numbers are layout-bound to one binary; conclusions rest on geomeans and cross-binary-reproduced effects).
- End-to-end (`comparative`, 74 decoder read cases, shipped tree): **geomean -17% vs `main`**; 66 faster / 4 flat / 4 slower. The only slowdowns are vbyte/LE reads (+2..+9%), which carry this branch's bounded-decode hardening; vbyte/BE reads got 7-9% faster.
- Non-peekable backends (new `benches/bufbitreader_wa.rs`, `WordAdapter` over an in-memory cursor, so `read_word_opt` returns `None`): read_bits -3/-4% (BE/LE), read_unary at parity with `main`.

## Remediation commits: disposition vs the new main

`main` already contains its own versions of: `copy_to`/`copy_from` 64-bit chunking, `into_inner` after a failed flush, retryable flush, `CountBitReader` success-only skip counting, `set_word_pos` fixes, `WordAdapter` overflow check, `Codes::len` 32-bit checked unary length, and Zeta(0)/Golomb(0) parse rejection.

Dropped as superseded: the old `copy_to`/full-buffer fix; the writer drop-flush change and `test_flush_error.rs` (they asserted semantics `main` deliberately rejected in favor of retryable flushes); `test_full_buffer.rs` (its states are unreachable under the new `PEEK_BITS`; the still-relevant top-up drain coverage moved into `tests/test_copy.rs` as `test_copy_to_after_topup`); the `read_unary` guard-workaround commit.

Kept (rebased, with conflicts resolved in `main`'s favor where it was newer): dispatch parameter/grammar validation (superset of `main`'s checks; serde inherits it via `FromStr`), write-params blanket, vbyte bounded decode, `CodesStats` overflow safety, `find_change`/`implied` fixes, `CountBitReader` u64 counters + post-peek-skip counting (keeps `main`'s no-count flush semantics and its regression test), CI action/container pinning + least-privilege permissions, dependency bounds + transitive `time` removal (RUSTSEC-2026-0009), python argv fixes (merged with `main`'s table-bits clamp), docs corrections, dispatch-matrix tests, unique temp file, vbyte bench isolation, `bench-u32` removal.

New in this revision:

- `fix(io)`: the std::io adapters transfer byte-by-byte -- honest partial progress at byte granularity (`main`'s 8-byte-chunked version can lose up to 7 tail bytes on an 8-aligned buffer at EOF), snapshot/restore on the write side so partial counts are retry-safe, and a documented, regression-tested exhaustion policy: reading past the end fails with `UnexpectedEof` rather than returning `Ok(0)`, because the generic backend error type cannot distinguish clean EOF from a backend failure, and silently converting failures into EOF would be worse (an empty `buf` still yields `Ok(0)` as the `Read` contract requires; `read_exact` and bounded `take` reads are covered by tests).
- `fix(reader)`: aligns the `peek_bits` contract with the new design -- the trait doc and both `BufBitReader` entry assertions still advertised `PeekWord::BITS`, but only `PEEK_BITS` (one word) is actually guaranteed; for a u32-word reader with an empty buffer, a documented `peek_bits(64)` could return an invalid partial value in release builds. Boundary tests on both sides: `peek_bits(PEEK_BITS)` from an empty buffer must be served by one refill (u16/u32/u64 words, both endians), and `peek_bits(PEEK_BITS + 1)` panics in debug builds.

## Verification

- `cargo fmt --check`; clippy default / `--no-default-features` / `--all-features --tests --benches`: zero warnings
- Tests: default, `--no-default-features` [+`alloc`] [+`alloc,no_copy_impls`], `--all-features` -- 12 suites each, 0 failures
- `cargo tree -i time`: gone; python tooling AST-checked; all benches compile
- CI at head `3f65b33`: all 36 checks pass (build matrix stable/beta/nightly x 5 feature sets, lint, MSRV 1.85, i686; coverage skips off-main by design)


